### PR TITLE
CMakeLists.txt:set build_type to "Release"

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.11)
+set(CMAKE_BUILD_TYPE  "Release")
 
 # Download and unpack googletest at configure time
 configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
@@ -71,7 +72,7 @@ add_library(pheval SHARED
   src/hashtable8.c
   src/hashtable9.c
 )
-target_include_directories(pheval PUBLIC include) 
+target_include_directories(pheval PUBLIC include)
 target_compile_options(pheval PUBLIC -Ofast)
 add_executable(unit_tests
   test/unit_tests.cc


### PR DESCRIPTION
fixes #8

```
2019-10-24 14:56:07
Running ./benchmark_phevaluator
Run on (4 X 3300 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 256K (x4)
  L3 Unified 6144K (x1)
Load Average: 1.11, 0.72, 0.89
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
```