### PR TITLE
correct an example command

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -29,7 +29,7 @@ code. In addition, at least C++11 standard is required.
 For example:
 
 ```bash
-g++ -I include/ -std=c++11 libpheval.a your_source_code.cc -o your_binary
+g++ -I include/ -std=c++11 your_source_code.cc libpheval.a -o your_binary
 ```
 
 ## Examples


### PR DESCRIPTION
It's a minor change request. But someone noob to C++ will be confused (I was confused).
Changed example command according to linking order dependency.
https://www.linuxtopia.org/online_books/an_introduction_to_gcc/gccintro_18.html