### PR TITLE
Add method of `Card` to describe its suit and rank

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Run script
         run: |
           cd python/phevaluator
-          python -m unittest tests.test_evaluator
+          python -m unittest discover tests

--- a/cpp/include/phevaluator/card.h
+++ b/cpp/include/phevaluator/card.h
@@ -21,6 +21,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <array>
 
 namespace phevaluator {
 const static std::unordered_map<char, int> rankMap = {
@@ -32,17 +33,15 @@ const static std::unordered_map<char, int> suitMap = {
   {'C', 0}, {'D', 1}, {'H', 2}, {'S', 3},
   {'c', 0}, {'d', 1}, {'h', 2}, {'s', 3},
 };
-const static std::unordered_map<int, char> rankReverseMap = {
-  {0, '2'}, {1, '3'}, {2, '4'}, {3, '5'},
-  {4, '6'}, {5, '7'}, {6, '8'}, {7, '9'},
-  {8, 'T'}, {9, 'J'}, {10, 'Q'}, {11, 'K'}, {12, 'A'},
+const static std::array<char, 13> rankReverseArray = {
+  '2', '3', '4', '5',
+  '6', '7', '8', '9',
+  'T', 'J', 'Q', 'K', 'A',
 };
-const static std::unordered_map<int, char> suitReverseMap = {
-  {0, 'c'}, {1, 'd'}, {2, 'h'}, {3, 's'},
-};
+const static std::array<char, 4> suitReverseArray = { 'c', 'd', 'h', 's' };
 
 class Card {
- public:
+public:
   Card() {}
 
   Card(int id) : id_(id) {}
@@ -57,13 +56,9 @@ class Card {
 
   Card(const char name[]) : Card(std::string(name)) {}
 
-  char describeRank(void) const {
-    return rankReverseMap.at(id_ / 4);
-  }
+  char describeRank(void) const { return rankReverseArray[id_ / 4]; }
 
-  char describeSuit(void) const {
-    return suitReverseMap.at(id_ % 4);
-  }
+  char describeSuit(void) const { return suitReverseArray[id_ % 4]; }
 
   std::string describeCard(void) const {
     return std::string{ describeRank(), describeSuit() };
@@ -73,7 +68,7 @@ class Card {
 
   operator std::string() const { return describeCard(); }
 
- private:
+private:
   int id_;
 };
 

--- a/cpp/include/phevaluator/card.h
+++ b/cpp/include/phevaluator/card.h
@@ -23,6 +23,23 @@
 #include <string>
 
 namespace phevaluator {
+const static std::unordered_map<char, int> rankMap = {
+  {'2', 0}, {'3', 1}, {'4', 2}, {'5', 3},
+  {'6', 4}, {'7', 5}, {'8', 6}, {'9', 7},
+  {'T', 8}, {'J', 9}, {'Q', 10}, {'K', 11}, {'A', 12},
+};
+const static std::unordered_map<char, int> suitMap = {
+  {'C', 0}, {'D', 1}, {'H', 2}, {'S', 3},
+  {'c', 0}, {'d', 1}, {'h', 2}, {'s', 3},
+};
+const static std::unordered_map<int, char> rankReverseMap = {
+  {0, '2'}, {1, '3'}, {2, '4'}, {3, '5'},
+  {4, '6'}, {5, '7'}, {6, '8'}, {7, '9'},
+  {8, 'T'}, {9, 'J'}, {10, 'Q'}, {11, 'K'}, {12, 'A'},
+};
+const static std::unordered_map<int, char> suitReverseMap = {
+  {0, 'c'}, {1, 'd'}, {2, 'h'}, {3, 's'},
+};
 
 class Card {
  public:
@@ -31,16 +48,6 @@ class Card {
   Card(int id) : id_(id) {}
 
   Card(std::string name) {
-    const std::unordered_map<char, int> rankMap = {
-      {'2', 0}, {'3', 1}, {'4', 2}, {'5', 3},
-      {'6', 4}, {'7', 5}, {'8', 6}, {'9', 7},
-      {'T', 8}, {'J', 9}, {'Q', 10}, {'K', 11}, {'A', 12},
-    };
-    const std::unordered_map<char, int> suitMap = {
-      {'C', 0}, {'D', 1}, {'H', 2}, {'S', 3},
-      {'c', 0}, {'d', 1}, {'h', 2}, {'s', 3},
-    };
-
     if (name.length() < 2) {
       // TODO: throw an exception here
     }
@@ -50,7 +57,21 @@ class Card {
 
   Card(const char name[]) : Card(std::string(name)) {}
 
+  char describeRank(void) const {
+    return rankReverseMap.at(id_ / 4);
+  }
+
+  char describeSuit(void) const {
+    return suitReverseMap.at(id_ % 4);
+  }
+
+  std::string describeCard(void) const {
+    return std::string{ describeRank(), describeSuit() };
+  }
+
   operator int() const { return id_; }
+
+  operator std::string() const { return describeCard(); }
 
  private:
   int id_;

--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ To run the unit test:
 
 ```
 cd phevaluator
-python3 -m unittest tests.test_evaluator
+python3 -m unittest discover tests
 ```
 
 There are also test code for testing the hash tables

--- a/python/phevaluator/evaluator/card.py
+++ b/python/phevaluator/evaluator/card.py
@@ -1,22 +1,40 @@
-class Card(int):
-    def __new__(cls, value):
-        rank_map = {
-            "2": 0,
-            "3": 1,
-            "4": 2,
-            "5": 3,
-            "6": 4,
-            "7": 5,
-            "8": 6,
-            "9": 7,
-            "T": 8,
-            "J": 9,
-            "Q": 10,
-            "K": 11,
-            "A": 12,
-        }
+from __future__ import annotations
 
-        suit_map = {"C": 0, "D": 1, "H": 2, "S": 3, "c": 0, "d": 1, "h": 2, "s": 3}
+from typing import Union
+
+# fmt: off
+rank_map = {
+    "2": 0, "3": 1, "4": 2, "5": 3, "6": 4, "7": 5, "8": 6, "9": 7,
+    "T": 8, "J": 9, "Q": 10, "K": 11, "A": 12,
+}
+suit_map = {
+    "C": 0, "D": 1, "H": 2, "S": 3,
+    "c": 0, "d": 1, "h": 2, "s": 3
+}
+# fmt: on
+
+rank_reverse_map = {value: key for key, value in rank_map.items()}
+suit_reverse_map = {value: key for key, value in suit_map.items() if key.islower()}
+
+
+class Card(int):
+    def __new__(cls, value: Union[int, str, Card]) -> Card:
         if isinstance(value, str):
-            value = rank_map[value[0]] * 4 + suit_map[value[1]]
+            rank, suit = value
+            value = rank_map[rank] * 4 + suit_map[suit]
         return super(Card, cls).__new__(cls, value)
+
+    def describe_rank(self) -> str:
+        return rank_reverse_map[self // 4]
+
+    def describe_suit(self) -> str:
+        return suit_reverse_map[self % 4]
+
+    def describe_card(self) -> str:
+        return self.describe_rank() + self.describe_suit()
+
+    def __str__(self) -> str:
+        return self.describe_card()
+
+    def __repr__(self) -> str:
+        return f'Card("{self.describe_card()}")'

--- a/python/phevaluator/evaluator/evaluator.py
+++ b/python/phevaluator/evaluator/evaluator.py
@@ -1,40 +1,23 @@
+from typing import Iterable, Union
+
+from evaluator.card import Card
 from evaluator.evaluator5 import evaluate_5cards
 from evaluator.evaluator6 import evaluate_6cards
 from evaluator.evaluator7 import evaluate_7cards
 from evaluator.evaluator_omaha import evaluate_omaha_cards
 
-rank_map = {
-    "2": 0,
-    "3": 1,
-    "4": 2,
-    "5": 3,
-    "6": 4,
-    "7": 5,
-    "8": 6,
-    "9": 7,
-    "T": 8,
-    "J": 9,
-    "Q": 10,
-    "K": 11,
-    "A": 12,
-}
 
-suit_map = {"C": 0, "D": 1, "H": 2, "S": 3, "c": 0, "d": 1, "h": 2, "s": 3}
+def evaluate_cards(*args: Iterable[Union[int, str, Card]]) -> int:
+    cards = list(map(Card, args))
 
-
-def evaluate_cards(*args):
-    if isinstance(args[0], str):
-        cards = []
-        for arg in args:
-            cards.append(rank_map[arg[0]] * 4 + suit_map[arg[1]])
-    else:
-        cards = tuple(args)
-
-    if len(args) == 5:
+    if len(cards) == 5:
         return evaluate_5cards(*cards)
-    elif len(args) == 6:
+
+    elif len(cards) == 6:
         return evaluate_6cards(*cards)
-    elif len(args) == 7:
+
+    elif len(cards) == 7:
         return evaluate_7cards(*cards)
-    elif len(args) == 9:
+
+    elif len(cards) == 9:
         return evaluate_omaha_cards(*cards)

--- a/python/phevaluator/tests/test_card.py
+++ b/python/phevaluator/tests/test_card.py
@@ -1,0 +1,69 @@
+import unittest
+import os
+
+from evaluator.card import Card
+
+
+class TestCard(unittest.TestCase):
+    # lowercase name, capitalcase name, value
+    testcases = [
+        ["2c", "2C", 0],
+        ["2d", "2D", 1],
+        ["2h", "2H", 2],
+        ["2s", "2S", 3],
+        ["Tc", "TC", 32],
+        ["Ac", "AC", 48],
+    ]
+
+    def test_card_equality(self):
+        for name, capital_name, number in self.testcases:
+            # equality between cards
+            self.assertEqual(Card(name), Card(number))  # e.g. Card("2c") == Card(0)
+            self.assertEqual(Card(capital_name), Card(number))  # e.g. Card("2C") == Card(0)
+            self.assertEqual(Card(Card(number)), Card(number))  # e.g. Card(Card(0)) == Card(0)
+            # equality between Card and int
+            self.assertEqual(Card(number), number)  # e.g. Card(0) == 0
+
+    def test_card_immutability(self):
+        # Once a Card is assigned or constructed from another Card, it's not affected by any changes to source variable
+        c_source = Card(1)
+        c_assign = c_source
+        c_construct = Card(c_source)
+
+        c_source += 1
+
+        self.assertNotEqual(c_source, Card(1))
+        self.assertEqual(c_assign, Card(1))
+        self.assertEqual(c_construct, Card(1))
+
+    def test_card_describe(self):
+        for name, capital_name, number in self.testcases:
+            rank, suit = name
+            c_name = Card(name)
+            c_capital_name = Card(capital_name)
+            c_number = Card(number)
+            c_construct = Card(c_number)
+
+            # Card("2c").describe_rank() == "2"
+            self.assertEqual(c_name.describe_rank(), rank)
+            # Card("2c").describe_suit() == "c"
+            self.assertEqual(c_name.describe_suit(), suit)
+
+            # Card("2c").describe_card() == "2c"
+            self.assertEqual(c_name.describe_card(), name)
+
+            # Card("2C").describe_card() == "2c"
+            self.assertEqual(c_capital_name.describe_card(), name)
+            # Card("2C").describe_card() != "2C"
+            self.assertNotEqual(c_capital_name.describe_card(), capital_name)
+
+            # Card(0).describe_card() == "2c"
+            self.assertEqual(c_number.describe_card(), name)
+
+            # Card(Card(0)).describe_card() == "2c"
+            self.assertEqual(c_construct.describe_card(), name)
+
+            # str(Card("2c")) == "2c"
+            self.assertEqual(str(c_name), name)
+            # repr(Card("2c")) == 'Card("2c")'
+            self.assertEqual(repr(c_name), f'Card("{name}")')

--- a/python/phevaluator/tests/test_evaluator.py
+++ b/python/phevaluator/tests/test_evaluator.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from evaluator.evaluator import evaluate_cards
+from evaluator.card import Card
 
 CARDS_FILE_5 = os.path.join(os.path.dirname(__file__), "cardfiles/5cards.json")
 CARDS_FILE_6 = os.path.join(os.path.dirname(__file__), "cardfiles/6cards.json")
@@ -47,3 +48,16 @@ class TestEvaluator(unittest.TestCase):
             hand_dict = json.load(read_file)
             for key, value in hand_dict.items():
                 self.assertEqual(evaluate_cards(*key.split()), value)
+
+    def test_evaluator_interface(self):
+        # int, str and Card can be passed to evaluate_cards()
+        p1 = evaluate_cards(1, 2, 3, 32, 48)
+        p2 = evaluate_cards("2d", "2h", "2s", "Tc", "Ac")
+        p3 = evaluate_cards("2D", "2H", "2S", "TC", "AC")
+        p4 = evaluate_cards(Card("2d"), Card("2h"), Card("2s"), Card("Tc"), Card("Ac"))
+        p5 = evaluate_cards(1, "2h", "2S", Card(32), Card("Ac"))
+
+        self.assertEqual(p1, p2)
+        self.assertEqual(p1, p3)
+        self.assertEqual(p1, p4)
+        self.assertEqual(p1, p5)


### PR DESCRIPTION
implementation of #37

### Python:
- `card.py`: the main update for Python
- `evaluator.py`: eliminate code duplication with `card.py` using its code change
- `test_card.py`: create new file to test `card.py`
- `test_evaluator.py`: add test for `evaluate_cards()` about integration with `Card`

### C++:
- `card.h`: the main update for C++

### Others:
- `ci.yml`: considering Python tests becoming across two files, test multiple files in `test` directory at once with `unittest`'s feature. checked that this worked.
- `README.md`: update about that