### PR TITLE
overloading hash<Card> with hash<int>

### DIFF
--- a/cpp/include/phevaluator/card.h
+++ b/cpp/include/phevaluator/card.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <string>
 #include <array>
+#include <functional>
 
 namespace phevaluator {
 const static std::unordered_map<char, int> rankMap = {
@@ -73,6 +74,16 @@ private:
 };
 
 } // namespace phevaluator
+
+
+namespace std {
+template <>
+struct hash<phevaluator::Card> {
+  size_t operator()(const phevaluator::Card& card) const {
+    return hash<int>()(int(card)); // usually identical to `return int(card)`
+  }
+};
+} // namespace std
 
 #endif // __cplusplus
 


### PR DESCRIPTION
Defined Hash for `Card` so that `unordered_set` and `unordered_map` (as key) can contain `Card` without user-defined hash table.