### PR TITLE
bug-fix #42 : define class methods in table_test properly

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -22,11 +22,7 @@ python3 -m unittest discover tests
 There are also test code for testing the hash tables
 ```
 cd phevaluator
-python3 -m table_tests.test_dptables
-python3 -m table_tests.test_hashtable
-python3 -m table_tests.test_hashtable5
-python3 -m table_tests.test_hashtable6
-python3 -m table_tests.test_hashtable7
+python3 -m unittest discover table_tests
 ```
 
 ## Using the library

--- a/python/phevaluator/table_tests/test_hashtable.py
+++ b/python/phevaluator/table_tests/test_hashtable.py
@@ -1,69 +1,79 @@
 import unittest
 from itertools import combinations
 
-from evaluator.hashtable import *
+from evaluator.hashtable import FLUSH
 
 
 class TestFlushTable(unittest.TestCase):
     TABLE = [0] * len(FLUSH)
     VISIT = [0] * len(FLUSH)
-    UPDATED = False
     CUR_RANK = 1
 
     CACHE = []
     BINARIES = []
 
-    def gen_binary(self, highest, k, n):
+    @classmethod
+    def setUpClass(cls):
+        cls.mark_straight()
+        cls.mark_four_of_a_kind()
+        cls.mark_full_house()
+        cls.mark_non_straight()
+
+    @classmethod
+    def gen_binary(cls, highest, k, n):
         if k == 0:
-            self.BINARIES.append(self.CACHE[:])
+            cls.BINARIES.append(cls.CACHE[:])
         else:
             for i in range(highest, -1, -1):
-                self.CACHE.append(i)
-                self.gen_binary(i - 1, k - 1, n)
-                self.CACHE.remove(i)
+                cls.CACHE.append(i)
+                cls.gen_binary(i - 1, k - 1, n)
+                cls.CACHE.remove(i)
 
-    def mark_straight(self):
+    @classmethod
+    def mark_straight(cls):
         for highest in range(12, 3, -1):  # From Ace to 6
             # k=5 case for base
             base = [highest - i for i in range(5)]
             base_idx = 0
             for pos in base:
                 base_idx += 1 << pos
-            self.TABLE[base_idx] = self.CUR_RANK
-            self.VISIT[base_idx] = 1
-            self.mark_six_to_nine(base, base_idx)
+            cls.TABLE[base_idx] = cls.CUR_RANK
+            cls.VISIT[base_idx] = 1
+            cls.mark_six_to_nine(base, base_idx)
 
             # setting up for the next loop
-            self.CUR_RANK += 1
+            cls.CUR_RANK += 1
 
         # Five High Straight Flush
         base = [12, 3, 2, 1, 0]
         base_idx = 0
         for pos in base:
             base_idx += 1 << pos
-        self.TABLE[base_idx] = self.CUR_RANK
-        self.VISIT[base_idx] = 1
-        self.mark_six_to_nine(base, base_idx)
-        self.CUR_RANK += 1
+        cls.TABLE[base_idx] = cls.CUR_RANK
+        cls.VISIT[base_idx] = 1
+        cls.mark_six_to_nine(base, base_idx)
+        cls.CUR_RANK += 1
 
-    def mark_non_straight(self):
-        self.gen_binary(12, 5, 5)
-        for base in self.BINARIES:
+    @classmethod
+    def mark_non_straight(cls):
+        cls.gen_binary(12, 5, 5)
+        for base in cls.BINARIES:
             base_idx = 0
             for pos in base:
                 base_idx += 1 << pos
 
-            if self.VISIT[base_idx] > 0:
+            if cls.VISIT[base_idx] > 0:
                 continue
 
-            self.TABLE[base_idx] = self.CUR_RANK
-            self.VISIT[base_idx] = 1
-            self.mark_six_to_nine(base, base_idx)
+            cls.TABLE[base_idx] = cls.CUR_RANK
+            cls.VISIT[base_idx] = 1
+            cls.mark_six_to_nine(base, base_idx)
 
             # setting up for the next loop
-            self.CUR_RANK += 1
+            cls.CUR_RANK += 1
 
-    def mark_six_to_nine(self, base, base_idx):
+    @classmethod
+    def mark_six_to_nine(cls, base, base_idx):
         # k=6-9 cases
         pos_candidates = [i for i in range(13) if i not in base]
         for r in [1, 2, 3, 4]:  # Need to select additional cards
@@ -72,31 +82,25 @@ class TestFlushTable(unittest.TestCase):
                 for pos in cb:
                     idx += 1 << pos
 
-                if self.VISIT[idx] > 0:
+                if cls.VISIT[idx] > 0:
                     continue
 
-                self.TABLE[idx] = self.CUR_RANK
-                self.VISIT[idx] = 1
+                cls.TABLE[idx] = cls.CUR_RANK
+                cls.VISIT[idx] = 1
 
-    def mark_four_of_a_kind(self):
+    @classmethod
+    def mark_four_of_a_kind(cls):
         # Four of a kind
         # The rank of the four cards: 13C1
         # The rank of the other card: 12C1
-        self.CUR_RANK += 13 * 12
+        cls.CUR_RANK += 13 * 12
 
-    def mark_full_house(self):
+    @classmethod
+    def mark_full_house(cls):
         # Full house
         # The rank of the cards of three of a kind: 13C1
         # The rank of the cards of a pair: 12C1
-        self.CUR_RANK += 13 * 12
-
-    def setUp(self):
-        if not self.UPDATED:
-            self.mark_straight()
-            self.mark_four_of_a_kind()
-            self.mark_full_house()
-            self.mark_non_straight()
-        self.UPDATED = True
+        cls.CUR_RANK += 13 * 12
 
     def test_flush_table(self):
         self.assertListEqual(self.TABLE, FLUSH)

--- a/python/phevaluator/table_tests/test_hashtable5.py
+++ b/python/phevaluator/table_tests/test_hashtable5.py
@@ -1,13 +1,12 @@
 import unittest
 
 from evaluator.hash import hash_quinary
-from evaluator.hashtable5 import *
+from evaluator.hashtable5 import NO_FLUSH_5
 
 
 class TestNoFlush5Table(unittest.TestCase):
     TABLE = [0] * len(NO_FLUSH_5)
     VISIT = [0] * len(NO_FLUSH_5)
-    UPDATED = False
     CUR_RANK = 1
     NUM_CARDS = 5
 
@@ -15,49 +14,65 @@ class TestNoFlush5Table(unittest.TestCase):
     USED = [0] * 13
     QUINARIES = []
 
-    def gen_quinary(self, k, n):
+    @classmethod
+    def setUpClass(cls):
+        cls.mark_straight_flush()
+        cls.mark_four_of_a_kind()
+        cls.mark_full_house()
+        cls.mark_flush()
+        cls.mark_straight()
+        cls.mark_three_of_a_kind()
+        cls.mark_two_pair()
+        cls.mark_one_pair()
+        cls.mark_high_card()
+
+    @classmethod
+    def gen_quinary(cls, k, n):
         if k == 0:
-            self.QUINARIES.append(self.CACHE[:])
+            cls.QUINARIES.append(cls.CACHE[:])
         else:
             for i in range(12, -1, -1):
-                if self.USED[i] > 0:
+                if cls.USED[i] > 0:
                     continue
-                self.CACHE.append(i)
-                self.USED[i] = 1
-                self.gen_quinary(k - 1, n)
-                self.CACHE.remove(i)
-                self.USED[i] = 0
+                cls.CACHE.append(i)
+                cls.USED[i] = 1
+                cls.gen_quinary(k - 1, n)
+                cls.CACHE.remove(i)
+                cls.USED[i] = 0
 
-    def mark_four_of_a_kind(self):
+    @classmethod
+    def mark_four_of_a_kind(cls):
         # Order 13C2 lexicographically
-        self.gen_quinary(2, 2)
-        for base in self.QUINARIES:
+        cls.gen_quinary(2, 2)
+        for base in cls.QUINARIES:
             idx = 0
             idx += (10 ** base[0]) * 4
             idx += 10 ** base[1]
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            self.TABLE[hash_] = self.CUR_RANK
-            self.VISIT[hash_] = 1
-            self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            cls.TABLE[hash_] = cls.CUR_RANK
+            cls.VISIT[hash_] = 1
+            cls.CUR_RANK += 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_full_house(self):
-        self.gen_quinary(2, 2)
-        for base in self.QUINARIES:
+    @classmethod
+    def mark_full_house(cls):
+        cls.gen_quinary(2, 2)
+        for base in cls.QUINARIES:
             idx = 0
             idx += (10 ** base[0]) * 3
             idx += (10 ** base[1]) * 2
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            self.TABLE[hash_] = self.CUR_RANK
-            self.VISIT[hash_] = 1
-            self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            cls.TABLE[hash_] = cls.CUR_RANK
+            cls.VISIT[hash_] = 1
+            cls.CUR_RANK += 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_straight(self):
+    @classmethod
+    def mark_straight(cls):
         for highest in range(12, 3, -1):  # From Ace to 6
             # k=5 case for base
             base = [highest - i for i in range(5)]
@@ -65,10 +80,10 @@ class TestNoFlush5Table(unittest.TestCase):
             for pos in base:
                 idx += 10 ** pos
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            self.TABLE[hash_] = self.CUR_RANK
-            self.VISIT[hash_] = 1
-            self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            cls.TABLE[hash_] = cls.CUR_RANK
+            cls.VISIT[hash_] = 1
+            cls.CUR_RANK += 1
 
         # Five High Straight Flush
         base = [12, 3, 2, 1, 0]
@@ -76,63 +91,67 @@ class TestNoFlush5Table(unittest.TestCase):
         for pos in base:
             idx += 10 ** pos
         hand = list(map(int, reversed("{:013d}".format(idx))))
-        hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-        self.TABLE[hash_] = self.CUR_RANK
-        self.VISIT[hash_] = 1
-        self.CUR_RANK += 1
+        hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+        cls.TABLE[hash_] = cls.CUR_RANK
+        cls.VISIT[hash_] = 1
+        cls.CUR_RANK += 1
 
-    def mark_three_of_a_kind(self):
-        self.gen_quinary(3, 3)
-        for base in self.QUINARIES:
+    @classmethod
+    def mark_three_of_a_kind(cls):
+        cls.gen_quinary(3, 3)
+        for base in cls.QUINARIES:
             idx = 0
             idx += (10 ** base[0]) * 3
             idx += 10 ** base[1]
             idx += 10 ** base[2]
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            if self.VISIT[hash_] == 0:
-                self.TABLE[hash_] = self.CUR_RANK
-                self.VISIT[hash_] = 1
-                self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            if cls.VISIT[hash_] == 0:
+                cls.TABLE[hash_] = cls.CUR_RANK
+                cls.VISIT[hash_] = 1
+                cls.CUR_RANK += 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_two_pair(self):
-        self.gen_quinary(3, 3)
-        for base in self.QUINARIES:
+    @classmethod
+    def mark_two_pair(cls):
+        cls.gen_quinary(3, 3)
+        for base in cls.QUINARIES:
             idx = 0
             idx += (10 ** base[0]) * 2
             idx += (10 ** base[1]) * 2
             idx += 10 ** base[2]
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            if self.VISIT[hash_] == 0:
-                self.TABLE[hash_] = self.CUR_RANK
-                self.VISIT[hash_] = 1
-                self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            if cls.VISIT[hash_] == 0:
+                cls.TABLE[hash_] = cls.CUR_RANK
+                cls.VISIT[hash_] = 1
+                cls.CUR_RANK += 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_one_pair(self):
-        self.gen_quinary(4, 4)
-        for base in self.QUINARIES:
+    @classmethod
+    def mark_one_pair(cls):
+        cls.gen_quinary(4, 4)
+        for base in cls.QUINARIES:
             idx = 0
             idx += (10 ** base[0]) * 2
             idx += 10 ** base[1]
             idx += 10 ** base[2]
             idx += 10 ** base[3]
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            if self.VISIT[hash_] == 0:
-                self.TABLE[hash_] = self.CUR_RANK
-                self.VISIT[hash_] = 1
-                self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            if cls.VISIT[hash_] == 0:
+                cls.TABLE[hash_] = cls.CUR_RANK
+                cls.VISIT[hash_] = 1
+                cls.CUR_RANK += 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_high_card(self):
-        self.gen_quinary(5, 5)
-        for base in self.QUINARIES:
+    @classmethod
+    def mark_high_card(cls):
+        cls.gen_quinary(5, 5)
+        for base in cls.QUINARIES:
             idx = 0
             idx += 10 ** base[0]
             idx += 10 ** base[1]
@@ -140,35 +159,24 @@ class TestNoFlush5Table(unittest.TestCase):
             idx += 10 ** base[3]
             idx += 10 ** base[4]
             hand = list(map(int, reversed("{:013d}".format(idx))))
-            hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-            if self.VISIT[hash_] == 0:
-                self.TABLE[hash_] = self.CUR_RANK
-                self.VISIT[hash_] = 1
-                self.CUR_RANK += 1
+            hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+            if cls.VISIT[hash_] == 0:
+                cls.TABLE[hash_] = cls.CUR_RANK
+                cls.VISIT[hash_] = 1
+                cls.CUR_RANK += 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_straight_flush(self):
+    @classmethod
+    def mark_straight_flush(cls):
         # A-5 High Straight Flush: 10
-        self.CUR_RANK += 10
+        cls.CUR_RANK += 10
 
-    def mark_flush(self):
+    @classmethod
+    def mark_flush(cls):
         # Selecting 5 cards in 13: 13C5
         # Need to exclude straight: -10
-        self.CUR_RANK += int(13 * 12 * 11 * 10 * 9 / (5 * 4 * 3 * 2)) - 10
-
-    def setUp(self):
-        if not self.UPDATED:
-            self.mark_straight_flush()
-            self.mark_four_of_a_kind()
-            self.mark_full_house()
-            self.mark_flush()
-            self.mark_straight()
-            self.mark_three_of_a_kind()
-            self.mark_two_pair()
-            self.mark_one_pair()
-            self.mark_high_card()
-            self.UPDATED = True
+        cls.CUR_RANK += int(13 * 12 * 11 * 10 * 9 / (5 * 4 * 3 * 2)) - 10
 
     def test_noflush5_table(self):
         self.assertListEqual(self.TABLE, NO_FLUSH_5)

--- a/python/phevaluator/table_tests/test_hashtable6.py
+++ b/python/phevaluator/table_tests/test_hashtable6.py
@@ -10,6 +10,10 @@ class TestNoFlush6Table(BaseTestNoFlushTable):
     VISIT = [0] * len(TOCOMPARE)
     NUM_CARDS = 6
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
     def test_noflush6_table(self):
         self.assertListEqual(self.TABLE, self.TOCOMPARE)
 

--- a/python/phevaluator/table_tests/test_hashtable7.py
+++ b/python/phevaluator/table_tests/test_hashtable7.py
@@ -10,6 +10,10 @@ class TestNoFlush7Table(BaseTestNoFlushTable):
     VISIT = [0] * len(TOCOMPARE)
     NUM_CARDS = 7
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
     def test_noflush7_table(self):
         self.assertListEqual(self.TABLE, self.TOCOMPARE)
 

--- a/python/phevaluator/table_tests/utils.py
+++ b/python/phevaluator/table_tests/utils.py
@@ -7,48 +7,62 @@ from evaluator.hashtable5 import NO_FLUSH_5
 class BaseTestNoFlushTable(unittest.TestCase):
     TABLE = NotImplementedError
     VISIT = NotImplementedError
-    UPDATED = False
     NUM_CARDS = NotImplementedError
 
-    CACHE = []
-    USED = [0] * 13
-    QUINARIES = []
+    @classmethod
+    def setUpClass(cls):
+        cls.CACHE = []
+        cls.USED = [0] * 13
+        cls.QUINARIES = []
 
-    def gen_quinary(self, ks, cur, additional):
+        cls.CACHE_ADDITIONAL = []
+        cls.USED_ADDITIONAL = [0] * 13
+        cls.QUINARIES_ADDITIONAL = []
+
+        # Straight Flushes are not in this table
+        cls.mark_four_of_a_kind()
+        cls.mark_full_house()
+        # Flushes are not in this table
+        cls.mark_straight()
+        cls.mark_three_of_a_kind()
+        cls.mark_two_pair()
+        cls.mark_one_pair()
+        cls.mark_high_card()
+
+    @classmethod
+    def gen_quinary(cls, ks, cur, additional):
         if cur == len(ks):
-            self.get_additional(additional)
-            self.QUINARIES.append((self.CACHE[:], self.QUINARIES_ADDITIONAL[:]))
-            self.QUINARIES_ADDITIONAL = []
+            cls.get_additional(additional)
+            cls.QUINARIES.append((cls.CACHE[:], cls.QUINARIES_ADDITIONAL[:]))
+            cls.QUINARIES_ADDITIONAL = []
         else:
             for i in range(12, -1, -1):
-                if self.USED[i] > 0:
+                if cls.USED[i] > 0:
                     continue
-                self.CACHE.append(i)
-                self.USED[i] = ks[cur]
-                self.gen_quinary(ks, cur + 1, additional)
-                self.CACHE.pop(-1)
-                self.USED[i] = 0
+                cls.CACHE.append(i)
+                cls.USED[i] = ks[cur]
+                cls.gen_quinary(ks, cur + 1, additional)
+                cls.CACHE.pop(-1)
+                cls.USED[i] = 0
 
-    CACHE_ADDITIONAL = []
-    USED_ADDITIONAL = [0] * 13
-    QUINARIES_ADDITIONAL = []
-
-    def get_additional(self, n):
+    @classmethod
+    def get_additional(cls, n):
         if n == 0:
-            self.QUINARIES_ADDITIONAL.append(self.CACHE_ADDITIONAL[:])
+            cls.QUINARIES_ADDITIONAL.append(cls.CACHE_ADDITIONAL[:])
         else:
             for i in range(12, -1, -1):
-                if self.USED[i] + self.USED_ADDITIONAL[i] >= 4:
+                if cls.USED[i] + cls.USED_ADDITIONAL[i] >= 4:
                     continue
-                self.CACHE_ADDITIONAL.append(i)
-                self.USED_ADDITIONAL[i] += 1
-                self.get_additional(n - 1)
-                self.CACHE_ADDITIONAL.pop(-1)
-                self.USED_ADDITIONAL[i] -= 1
+                cls.CACHE_ADDITIONAL.append(i)
+                cls.USED_ADDITIONAL[i] += 1
+                cls.get_additional(n - 1)
+                cls.CACHE_ADDITIONAL.pop(-1)
+                cls.USED_ADDITIONAL[i] -= 1
 
-    def mark_template(self, ks):
-        self.gen_quinary(ks, 0, self.NUM_CARDS - 5)
-        for base, additionals in self.QUINARIES:
+    @classmethod
+    def mark_template(cls, ks):
+        cls.gen_quinary(ks, 0, cls.NUM_CARDS - 5)
+        for base, additionals in cls.QUINARIES:
             base_idx = 0
             for i in range(len(ks)):
                 base_idx += (10 ** base[i]) * ks[i]
@@ -59,66 +73,60 @@ class BaseTestNoFlushTable(unittest.TestCase):
                 for i in additional:
                     idx += 10 ** i
                 hand = list(map(int, reversed("{:013d}".format(idx))))
-                hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-                if self.VISIT[hash_] > 0:
+                hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+                if cls.VISIT[hash_] > 0:
                     continue
-                self.TABLE[hash_] = base_rank
-                self.VISIT[hash_] = 1
+                cls.TABLE[hash_] = base_rank
+                cls.VISIT[hash_] = 1
 
-        self.QUINARIES = []
+        cls.QUINARIES = []
 
-    def mark_four_of_a_kind(self):
-        self.mark_template((4, 1))
+    @classmethod
+    def mark_four_of_a_kind(cls):
+        cls.mark_template((4, 1))
 
-    def mark_full_house(self):
-        self.mark_template((3, 2))
+    @classmethod
+    def mark_full_house(cls):
+        cls.mark_template((3, 2))
 
-    def mark_three_of_a_kind(self):
-        self.mark_template((3, 1, 1))
+    @classmethod
+    def mark_three_of_a_kind(cls):
+        cls.mark_template((3, 1, 1))
 
-    def mark_two_pair(self):
-        self.mark_template((2, 2, 1))
+    @classmethod
+    def mark_two_pair(cls):
+        cls.mark_template((2, 2, 1))
 
-    def mark_one_pair(self):
-        self.mark_template((2, 1, 1, 1))
+    @classmethod
+    def mark_one_pair(cls):
+        cls.mark_template((2, 1, 1, 1))
 
-    def mark_high_card(self):
-        self.mark_template((1, 1, 1, 1, 1))
+    @classmethod
+    def mark_high_card(cls):
+        cls.mark_template((1, 1, 1, 1, 1))
 
-    def mark_straight(self):
+    @classmethod
+    def mark_straight(cls):
         cases = [[highest - i for i in range(5)] for highest in range(12, 3, -1)]
         cases.append([12, 3, 2, 1, 0])
         for base in cases:
             base_idx = 0
             for pos in base:
                 base_idx += 10 ** pos
-                self.USED[pos] = 1
+                cls.USED[pos] = 1
             hand = list(map(int, reversed("{:013d}".format(base_idx))))
             base_rank = NO_FLUSH_5[hash_quinary(hand, 13, 5)]
-            self.get_additional(self.NUM_CARDS - 5)
-            additionals = self.QUINARIES_ADDITIONAL[:]
-            self.QUINARIES_ADDITIONAL = []
-            self.USED = [0] * 13
+            cls.get_additional(cls.NUM_CARDS - 5)
+            additionals = cls.QUINARIES_ADDITIONAL[:]
+            cls.QUINARIES_ADDITIONAL = []
+            cls.USED = [0] * 13
             for additional in additionals:
                 idx = base_idx
                 for i in additional:
                     idx += 10 ** i
                 hand = list(map(int, reversed("{:013d}".format(idx))))
-                hash_ = hash_quinary(hand, 13, self.NUM_CARDS)
-                if self.VISIT[hash_] > 0:
+                hash_ = hash_quinary(hand, 13, cls.NUM_CARDS)
+                if cls.VISIT[hash_] > 0:
                     continue
-                self.TABLE[hash_] = base_rank
-                self.VISIT[hash_] = 1
-
-    def setUp(self):
-        if not self.UPDATED:
-            # Straight Flushes are not in this table
-            self.mark_four_of_a_kind()
-            self.mark_full_house()
-            # Flushes are not in this table
-            self.mark_straight()
-            self.mark_three_of_a_kind()
-            self.mark_two_pair()
-            self.mark_one_pair()
-            self.mark_high_card()
-            self.UPDATED = True
+                cls.TABLE[hash_] = base_rank
+                cls.VISIT[hash_] = 1


### PR DESCRIPTION
bug-fix of #42. 

- replace most of instance methods with class methods and static methods.

- replace `setUp` (run by instance) with `setUpClass` (run by class) and delete the `UPDATED` flag that prevents from running same process by each instance.
https://docs.python.org/3/library/unittest.html#unittest.TestCase.setUpClass

- It is because `TestNoFlush6Table` and `TestNoFlush7Table` share base class's class variable `CACHE`, `USED`, `QUINARIES`, `CACHE_ADDITIONAL`, `CACHE_ADDITIONAL` and `QUINARIES_ADDITIONAL` that the bug happens. So each of classes call `setUpClass` of base class `BaseTestNoFlushTable` and initialize separately.