### PR TITLE
fix package not containing entire codes and omaha data

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = phevaluator
-version = 0.5.0
+version = 0.5.1
 description = PH Evaluator - an efficient Poker Hand Evaluator based on a Perfect Hash algorithm
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -32,11 +32,9 @@ project_urls =
 
 [options]
 python_requires= >=3.6, <4
-package_dir =
-    = phevaluator
 packages = find:
 install_requires =
     numpy
 
-[options.packages.find]
-where = phevaluator
+[options.package_data]
+phevaluator = tables/*.dat


### PR DESCRIPTION
The package uploaded to PyPI does not contain all of the codes except tables and Omaha data (`omaha_flush.dat`, `omaha_noflush.dat`).
In other words, if we run `pip install phevaluator==0.5.0`, we cannot do `import phevaluator`.

I apply this hotfix to the v0.5.0 commit [`84764bb`](https://github.com/HenryRLee/PokerHandEvaluator/commit/84764bb875a47ad04dc0cae678551436dafb0d9a) and uploaded it to PyPI.
That version in PyPI is 0.5.0.4. (equivalent to v0.5.0 but fixed)
Although there is a test environment for PyPI, it cannot resolve dependencies for setuptools so that the trials in the live environment was required and that increases the version in PyPI as release overwritten is protected.
As a result, if we run `pip install phevaluator` or `pip install phevaluator==0.5.0.4`, we can do `import phevaluator`.

I also apply this hotfix to  the latest master commit [`2f282ad`](https://github.com/HenryRLee/PokerHandEvaluator/commit/2f282ad1a08acc9733402b2c8ba024d6f5ef6944)
The result of that is this PR.
That version in `setup.cfg` is 0.5.1 to be distinguish from the above release but I didn't give tag in git either not upload to PyPI.
We can build and upload it to PyPI as v0.5.1 (or higher) whenever it's needed. 

---

The modification is...
- Set the root directory as same as `setup.cfg` i.e. `./` instead of `./phevaluator`.
- Add data `./phevaluator/tables/*.dat`.