### PR TITLE
Zig build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,28 +28,34 @@ jobs:
         uses: goto-bus-stop/setup-zig@v1.3.0
         with:
           version: master
-      - run: | 
-          cd cpp
-          zig build -Drelease-fast
-      - run: | 
-          cd cpp
-          zig build -Ddynamic -Drelease-fast
-      - run: | 
-          cd cpp
-          zig build -Dtarget=x86_64-windows -Drelease-fast
-      - run: | 
-          cd cpp
-          zig build -Domaha -Drelease-fast
-      - run: | 
-          cd cpp
-          zig build -Domaha -Ddynamic -Drelease-fast
-      - run: | 
-          cd cpp
-          zig build -Domaha -Ddynamic -Dtarget=x86_64-windows -Drelease-fast
-      - name: Run examples with zig
+      - name: zig build -Drelease-fast
         run: | 
           cd cpp
-          zig build examples -Drelease-fast
+          zig build -Drelease-fast
+      - name: zig build -Ddynamic -Drelease-fast
+        run: | 
+          cd cpp
+          zig build -Ddynamic -Drelease-fast
+      - name: zig build -Dtarget=x86_64-windows -Drelease-fast
+        run: | 
+          cd cpp
+          zig build -Dtarget=x86_64-windows -Drelease-fast
+      - name: zig build -Domaha -Drelease-fast
+        run: | 
+          cd cpp
+          zig build -Domaha -Drelease-fast
+      - name: zig build -Domaha -Ddynamic -Drelease-fast
+        run: | 
+          cd cpp
+          zig build -Domaha -Ddynamic -Drelease-fast
+      - name: zig build -Domaha -Ddynamic -Dtarget=x86_64-windows -Drelease-fast
+        run: | 
+          cd cpp
+          zig build -Domaha -Ddynamic -Dtarget=x86_64-windows -Drelease-fast
+      - name: zig build and run examples
+        run: | 
+          cd cpp
+          zig build examples
           zig-out/bin/c_example
           zig-out/bin/cpp_example
           zig-out/bin/omaha_example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,35 @@ jobs:
           ./cpp_example
           ./omaha_example
           ./unit_tests
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v1.3.0
+        with:
+          version: master
+      - run: | 
+          cd cpp
+          zig build -Drelease-fast
+      - run: | 
+          cd cpp
+          zig build -Ddynamic -Drelease-fast
+      - run: | 
+          cd cpp
+          zig build -Dtarget=x86_64-windows -Drelease-fast
+      - run: | 
+          cd cpp
+          zig build -Domaha -Drelease-fast
+      - run: | 
+          cd cpp
+          zig build -Domaha -Ddynamic -Drelease-fast
+      - run: | 
+          cd cpp
+          zig build -Domaha -Ddynamic -Dtarget=x86_64-windows -Drelease-fast
+      - name: Run examples with zig
+        run: | 
+          cd cpp
+          zig build examples -Drelease-fast
+          zig-out/bin/c_example
+          zig-out/bin/cpp_example
+          zig-out/bin/omaha_example
   cpp_benchmark:
     name: C++ Benchmark
     runs-on: ubuntu-latest

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -14,3 +14,6 @@ cmake_install.cmake
 googletest-build/
 googletest-download/
 googletest-src/
+
+zig-out/
+zig-cache/

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -22,7 +22,7 @@ Run the `unit_tests` to perform the unit tests:
 
 ### Compile with zig
 
-This library can also be build with zig which supports many platforms and cross compilation scenarios.  In order to do so, [install a zig compiler](https://github.com/ziglang/zig#installation) for your platform and run `zig build` with some combination of the following flags:
+This library can also be build with zig which supports many platforms and cross compilation scenarios.  In order to do so, [install a zig compiler](https://github.com/ziglang/zig#installation) for your platform (minimum version 0.9) and run `zig build` with some combination of the following flags:
 
 ```console
 # show available build options
@@ -38,7 +38,7 @@ $ zig build -Ddynamic -Drelease-fast
 $ zig build -Dtarget=x86_64-windows -Drelease-fast
 
 # create zig-out/lib/libphevalomaha.a 
-zig build -Domaha -Drelease-fast
+$ zig build -Domaha -Drelease-fast
 ```
 
 ## Use the library

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -20,6 +20,27 @@ Run the `unit_tests` to perform the unit tests:
 ./unit_tests
 ```
 
+### Compile with zig
+
+This library can also be build with zig which supports many platforms and cross compilation scenarios.  In order to do so, [install a zig compiler](https://github.com/ziglang/zig#installation) for your platform and run `zig build` with some combination of the following flags:
+
+```console
+# show available build options
+$ zig build --help
+
+# create an optimized zig-out/lib/libpheval.a (or .lib on windows) 
+$ zig build -Drelease-fast
+
+# create an optimized zig-out/lib/libpheval.so (or .dll/.pdb on windows)
+$ zig build -Ddynamic -Drelease-fast
+
+# cross-compile for windows from another platform. creates zig-out/lib/libpheval.dll/pdb
+$ zig build -Dtarget=x86_64-windows -Drelease-fast
+
+# create zig-out/lib/libphevalomaha.a 
+zig build -Domaha -Drelease-fast
+```
+
 ## Use the library
 
 After building the library `libpheval.a`, you can add the `./include`

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -39,6 +39,9 @@ $ zig build -Dtarget=x86_64-windows -Drelease-fast
 
 # create zig-out/lib/libphevalomaha.a 
 $ zig build -Domaha -Drelease-fast
+
+# create example executables in zig-out/bin/
+$ zig build examples
 ```
 
 ## Use the library

--- a/cpp/build.zig
+++ b/cpp/build.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+    const lib = b.addStaticLibrary("pheval", null);
+    const opts = b.addOptions();
+    const dynamic = b.option(bool, "dynamic", "build dynamic or static lib") orelse false;
+    opts.addOption(bool, "dynamic", dynamic);
+
+    lib.linkage = if (dynamic) .dynamic else .static;
+    lib.setBuildMode(mode);
+    lib.setTarget(target);
+    lib.addCSourceFiles(
+        &.{
+            "src/evaluator5.c",
+            "src/hashtable5.c",
+            "src/evaluator6.c",
+            "src/hashtable6.c",
+            "src/evaluator7.c",
+            "src/hashtable7.c",
+            "src/hash.c",
+            "src/hashtable.c",
+            "src/dptables.c",
+            "src/rank.c",
+            "src/7462.c",
+        },
+        &.{"-std=c99"},
+    );
+    lib.addCSourceFiles(
+        &.{
+            "src/evaluator.cc",
+            "src/hand.cc",
+        },
+        &.{"-std=c++14"},
+    );
+    lib.addIncludeDir("include");
+    lib.linkLibCpp();
+    lib.install();
+
+    var main_tests = b.addTest("src/main.zig");
+    main_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&main_tests.step);
+}


### PR DESCRIPTION
this patch allows building with the zig compiler in order to make compiling on other platforms and cross-compilation to other platforms easier.  the zig compiler supports building c/c++ code via libclang on many platforms (https://ziglang.org/download/).  it supports cross compiling to all major platforms by bundling a variety of different libcs.  