### PR TITLE
Fix a bug in C++ hand comparison

### DIFF
--- a/cpp/include/phevaluator/rank.h
+++ b/cpp/include/phevaluator/rank.h
@@ -84,19 +84,19 @@ class Rank {
   int value() const { return value_; }
 
   bool operator<(const Rank& other) const {
-    return value_ >= other.value_;
-  }
-
-  bool operator<=(const Rank& other) const {
     return value_ > other.value_;
   }
 
+  bool operator<=(const Rank& other) const {
+    return value_ >= other.value_;
+  }
+
   bool operator>(const Rank& other) const {
-    return value_ <= other.value_;
+    return value_ < other.value_;
   }
 
   bool operator>=(const Rank& other) const {
-    return value_ < other.value_;
+    return value_ <= other.value_;
   }
 
   bool operator==(const Rank& other) const {


### PR DESCRIPTION
A better hand is a hand with a lower rank value. When checking if a hand `A` is strictly better than another hand `B`, we need to check whether `A.value_` is strictly less than `B.value_` and vice versa. When checking if a hand `A` is better than or equal to another hand `B`, we need to check whether `A.value_` is less than or equal to `B.value_` and vice versa. Given two identical hands `A` and `B`, the current code will return `false` for `A <= B`, when in fact it should return `true`.