### PR TITLE
Match cpp_example output to assertion

### DIFF
--- a/cpp/examples/cpp_example.cc
+++ b/cpp/examples/cpp_example.cc
@@ -28,7 +28,7 @@ int main()
   std::cout << "Player 2 has a " << rank2.describeCategory() << std::endl;
 
   assert(rank2.describeRank() == "Nines Full over Fours");
-  std::cout << "More specifically, player 2 has a " << rank2.describeCategory() << std::endl;
+  std::cout << "More specifically, player 2 has a " << rank2.describeRank() << std::endl;
 
   assert(rank2.describeSampleHand() == "99944");
   assert(!rank2.isFlush());


### PR DESCRIPTION
Fixes `cpp_example`. Small code change that appears to match the intent of the example.

Output before fix:

```
% ./cpp_example                 
The rank of the hand in player 1 is 292
The rank of the hand in player 2 is 236
Player 2 has a stronger hand
Player 2 has a Full House
More specifically, player 2 has a Full House
The best hand from player 2 is 99944
```

Output after fix:

```
% ./cpp_example
The rank of the hand in player 1 is 292
The rank of the hand in player 2 is 236
Player 2 has a stronger hand
Player 2 has a Full House
More specifically, player 2 has a Nines Full over Fours
The best hand from player 2 is 99944
```