### PR TITLE
Add module lazy loading in __init__ files

### DIFF
--- a/python/phevaluator/__init__.py
+++ b/python/phevaluator/__init__.py
@@ -1,11 +1,30 @@
 """Package for evaluating a poker hand."""
 from . import hash as hash_  # FIXME: `hash` collides to built-in function
-from . import tables
-from .card import Card
-from .evaluator import _evaluate_cards, evaluate_cards
-from .evaluator_omaha import _evaluate_omaha_cards, evaluate_omaha_cards
-from .utils import sample_cards
 
-__all__ = ["tables", "Card", "evaluate_cards", "evaluate_omaha_cards", "sample_cards"]
+
+# import mapping to objects in other modules
+all_by_module = {
+    "phevaluator": ["card", "evaluator_omaha", "evaluator", "hash", "tables", "utils"],
+    "phevaluator.card": ["Card"],
+    "phevaluator.evaluator": ["_evaluate_cards", "evaluate_cards"],
+    "phevaluator.evaluator_omaha": ["_evaluate_omaha_cards", "evaluate_omaha_cards"],
+    "phevaluator.utils": ["sample_cards"]
+}
+
+# Based on werkzeug library
+object_origins = {}
+for module, items in all_by_module.items():
+    for item in items:
+        object_origins[item] = module
 
 __docformat__ = "google"
+
+
+# Based on https://peps.python.org/pep-0562/ and werkzeug library
+def __getattr__(name):
+    """lazy submodule imports"""
+    if name in object_origins:
+        module = __import__(object_origins[name], None, None, [name])
+        return getattr(module, name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/phevaluator/tables/__init__.py
+++ b/python/phevaluator/tables/__init__.py
@@ -1,24 +1,18 @@
-"""Pre-calculated tables."""
-from .dptables import CHOOSE, DP, SUITS
-from .hashtable import FLUSH
-from .hashtable5 import NO_FLUSH_5
-from .hashtable6 import NO_FLUSH_6
-from .hashtable7 import NO_FLUSH_7
-from .hashtable_omaha import FLUSH_OMAHA, NO_FLUSH_OMAHA
+# import mapping to pre-calculated tables in other modules
+all_by_module = {
+    "phevaluator.tables.dptables": ["CHOOSE", "DP", "SUITS"],
+    "phevaluator.tables.hashtable": ["FLUSH"],
+    "phevaluator.tables.hashtable5": ["NO_FLUSH_5"],
+    "phevaluator.tables.hashtable6": ["NO_FLUSH_6"],
+    "phevaluator.tables.hashtable7": ["NO_FLUSH_7"],
+    "phevaluator.tables.hashtable_omaha": ["FLUSH_OMAHA", "NO_FLUSH_OMAHA"]
+}
 
-__all__ = [
-    "BINARIES_BY_ID",
-    "CHOOSE",
-    "DP",
-    "SUITBIT_BY_ID",
-    "SUITS",
-    "FLUSH",
-    "NO_FLUSH_5",
-    "NO_FLUSH_6",
-    "NO_FLUSH_7",
-    "FLUSH_OMAHA",
-    "NO_FLUSH_OMAHA",
-]
+# Based on werkzeug library
+object_origins = {}
+for module, items in all_by_module.items():
+    for item in items:
+        object_origins[item] = module
 
 # fmt: off
 BINARIES_BY_ID = [
@@ -39,3 +33,13 @@ BINARIES_BY_ID = [
 
 SUITBIT_BY_ID = [0x1, 0x8, 0x40, 0x200] * 13
 # fmt: on
+
+
+# Based on https://peps.python.org/pep-0562/ and werkzeug library
+def __getattr__(name):
+    """lazy submodule imports"""
+    if name in object_origins:
+        module = __import__(object_origins[name], None, None, [name])
+        return getattr(module, name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
This commit was made to avoid loading all of the tables when not required. This brings down the memory usage from ~400Mib to ~2MiB.

Flake8 was applied apart from line length which was ignored. For coding references I used PEP 562 and the werkzeug library to ensure I was using proper reference points.

I tested this using the following Python script:
```
from memory_profiler import profile


@profile
def import_phevaluator():
    from phevaluator import evaluator
    print(evaluator.evaluate_cards('2d', '3d', '4d', '5d', '6d', '7d', '8d'))


@profile
def import_omaha_phevaluator():
    from phevaluator import evaluator_omaha
    print(evaluator_omaha.evaluate_omaha_cards('2d', '3d', '4d', '5d', '6d', '7d', '8d', '9d', 'Td'))


if __name__ == "__main__":
    import_phevaluator()
    import_omaha_phevaluator()
```

With the output:
```
7
Filename: test_script.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     4     22.8 MiB     22.8 MiB           1   @profile
     5                                         def import_phevaluator():
     6     25.0 MiB      2.2 MiB           1       from phevaluator import evaluator
     7     25.0 MiB      0.0 MiB           1       print(evaluator.evaluate_cards('2d', '3d', '4d', '5d', '6d', '7d', '8d'))


7
Filename: test_script.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    10     25.1 MiB     25.1 MiB           1   @profile
    11                                         def import_omaha_phevaluator():
    12    423.1 MiB    398.1 MiB           1       from phevaluator import evaluator_omaha
    13    423.1 MiB      0.0 MiB           1       print(evaluator_omaha.evaluate_omaha_cards('2d', '3d', '4d', '5d', '6d', '7d', '8d', '9d', 'Td'))
```

These tests were surface level, please validate my work further as I am still not fully familiar with this library.