### PR TITLE
Fix type annotations with using `type.List`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.x

--- a/python/phevaluator/evaluator_omaha.py
+++ b/python/phevaluator/evaluator_omaha.py
@@ -1,7 +1,8 @@
 """Module evaluating cards in Omaha game."""
+
 from __future__ import annotations
 
-from typing import Union
+from typing import List, Union
 
 from .card import Card
 from .hash import hash_binary, hash_quinary
@@ -51,7 +52,7 @@ def evaluate_omaha_cards(*cards: Union[int, str, Card]) -> int:
     return _evaluate_omaha_cards(community_cards, hole_cards)
 
 
-def _evaluate_omaha_cards(community_cards: [int], hole_cards: [int]) -> int:
+def _evaluate_omaha_cards(community_cards: List[int], hole_cards: List[int]) -> int:
     value_flush = 10000
     value_noflush = 10000
     suit_count_board = [0] * 4

--- a/python/phevaluator/hash.py
+++ b/python/phevaluator/hash.py
@@ -1,14 +1,17 @@
 """Module hashing cards."""
+
 from __future__ import annotations
+
+from typing import List
 
 from .tables import CHOOSE, DP
 
 
-def hash_quinary(quinary: [int], num_cards: int) -> int:
+def hash_quinary(quinary: List[int], num_cards: int) -> int:
     """Hash list of cards.
 
     Args:
-        quinary ([int]): List of the count of the cards.
+        quinary (List[int]): List of the count of the cards.
         num_cards (int): The number of cards.
 
     Returns:

--- a/python/phevaluator/utils.py
+++ b/python/phevaluator/utils.py
@@ -1,9 +1,18 @@
 """Utilities."""
+
 from __future__ import annotations
 
 import random
+from typing import List
 
 
-def sample_cards(size: int) -> [int]:
-    """Sample random cards with size."""
+def sample_cards(size: int) -> List[int]:
+    """Sample random cards with size.
+
+    Args:
+        size (int): The size of the sample.
+
+    Returns:
+        List[int]: The list of the sampled cards.
+    """
     return random.sample(range(52), k=size)

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -32,7 +31,7 @@ project_urls =
     Source = https://github.com/HenryRLee/PokerHandEvaluator/tree/master/python
 
 [options]
-python_requires= >=3.7, <4
+python_requires= >=3.8, <4
 packages = find:
 install_requires =
     numpy

--- a/python/tests/table_tests/test_hashtable.py
+++ b/python/tests/table_tests/test_hashtable.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 from itertools import combinations
+from typing import List
 
 from phevaluator.tables import FLUSH
 
@@ -11,8 +12,8 @@ class TestFlushTable(unittest.TestCase):
     VISIT = [0] * len(FLUSH)
     CUR_RANK = 1
 
-    CACHE: [int] = []
-    BINARIES: [int] = []
+    CACHE: List[int] = []
+    BINARIES: List[List[int]] = []
 
     @classmethod
     def setUpClass(cls):

--- a/python/tests/table_tests/utils.py
+++ b/python/tests/table_tests/utils.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import unittest
 from itertools import combinations, combinations_with_replacement, permutations
+from typing import List
 
 from phevaluator.hash import hash_quinary
 from phevaluator.tables import NO_FLUSH_5
 
 
 class BaseTestNoFlushTable(unittest.TestCase):
-    TABLE: [int] = NotImplemented
-    VISIT: [int] = NotImplemented
+    TABLE: List[int] = NotImplemented
+    VISIT: List[int] = NotImplemented
     NUM_CARDS: int = NotImplemented
 
     @classmethod

--- a/python/tests/test_evalator_omaha.py
+++ b/python/tests/test_evalator_omaha.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 from itertools import combinations
+from typing import List
 
 from phevaluator import (
     Card,
@@ -12,7 +13,7 @@ from phevaluator import (
 )
 
 
-def evaluate_omaha_exhaustive(community_cards: [int], hole_cards: [int]) -> int:
+def evaluate_omaha_exhaustive(community_cards: List[int], hole_cards: List[int]) -> int:
     """Evaluate omaha cards with `_evaluate_cards`."""
     best_rank = min(
         _evaluate_cards(c1, c2, c3, h1, h2)


### PR DESCRIPTION
Fix type annotations in Python for issue #75
This pull request addresses the type annotation errors raised by mypy when running `mypy .`. The necessary changes have been made to resolve these errors.

Additonal Notes:
* We should consider defining and documenting a set of linters that our project should adhere to. These linters can be integrated into our GitHub Actions workflow using tools like the Super-Linter (https://github.com/marketplace/actions/super-linter).
* Python 3.7 has been deprecated in this pull request. For more information on Python version support, please refer to the Python Developer's Guide: https://devguide.python.org/versions/

