### PR TITLE
Move `CardSampler` to separate files and use it in evaluation tests

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ option(BUILD_TESTS "Build test ON/OFF" ON)
 option(BUILD_EXAMPLES "Build examples ON/OFF" ON)
 
 add_library(pheval STATIC
+  src/card_sampler.cc
   src/dptables.c
   src/evaluator5.cc
   src/evaluator5.c
@@ -41,6 +42,7 @@ target_include_directories(pheval PUBLIC
 target_compile_options(pheval PUBLIC -O3)
 set(PUB_HEADERS include/phevaluator/phevaluator.h
                 include/phevaluator/card.h
+                include/phevaluator/card_sampler.h
                 include/phevaluator/rank.h)
 set_target_properties(pheval PROPERTIES
     VERSION ${PROJECT_VERSION}
@@ -114,6 +116,7 @@ endif()
 
 if (BUILD_PLO4)
   add_library(phevalplo4 STATIC
+    src/card_sampler.cc
     src/dptables.c
     src/evaluator_plo4.c
     src/evaluator_plo4.cc
@@ -130,6 +133,7 @@ if (BUILD_PLO4)
   target_compile_options(phevalplo4 PUBLIC -O3)
   set(PUB_HEADERS include/phevaluator/phevaluator.h
                   include/phevaluator/card.h
+                  include/phevaluator/card_sampler.h
                   include/phevaluator/rank.h)
   set_target_properties(phevalplo4 PROPERTIES
       VERSION ${PROJECT_VERSION}
@@ -148,6 +152,7 @@ if (BUILD_PLO5)
   )
 
   add_library(phevalplo5 STATIC
+    src/card_sampler.cc
     src/dptables.c
     src/evaluator_plo5.c
     src/evaluator_plo5.cc
@@ -164,6 +169,7 @@ if (BUILD_PLO5)
   target_compile_options(phevalplo5 PUBLIC -O3)
   set(PUB_HEADERS include/phevaluator/phevaluator.h
                   include/phevaluator/card.h
+                  include/phevaluator/card_sampler.h
                   include/phevaluator/rank.h)
   set_target_properties(phevalplo5 PROPERTIES
       VERSION ${PROJECT_VERSION}
@@ -181,6 +187,7 @@ if (BUILD_PLO6)
   )
 
   add_library(phevalplo6 STATIC
+    src/card_sampler.cc
     src/dptables.c
     src/evaluator_plo6.c
     src/evaluator_plo6.cc
@@ -197,6 +204,7 @@ if (BUILD_PLO6)
   target_compile_options(phevalplo6 PUBLIC -O3)
   set(PUB_HEADERS include/phevaluator/phevaluator.h
                   include/phevaluator/card.h
+                  include/phevaluator/card_sampler.h
                   include/phevaluator/rank.h)
   set_target_properties(phevalplo6 PROPERTIES
       VERSION ${PROJECT_VERSION}

--- a/cpp/benchmark/benchmark.cc
+++ b/cpp/benchmark/benchmark.cc
@@ -1,6 +1,6 @@
-#include "phevaluator/phevaluator.h"
 #include "benchmark/benchmark.h"
-#include "card_sampler.h"
+#include "phevaluator/card_sampler.h"
+#include "phevaluator/phevaluator.h"
 
 using namespace phevaluator;
 
@@ -65,16 +65,13 @@ const int SIZE = 100;
 
 static void EvaluateRandomFiveCards(benchmark::State& state) {
   std::vector<std::vector<int>> hands;
-  CardSampler cs{};
+  card_sampler::CardSampler cs{};
   for (int i = 0; i < SIZE; i++) {
     hands.push_back(cs.sample(5));
   }
   for (auto _ : state) {
     for (int i = 0; i < SIZE; i++) {
-      EvaluateCards(hands[i][0],
-                    hands[i][1],
-                    hands[i][2],
-                    hands[i][3],
+      EvaluateCards(hands[i][0], hands[i][1], hands[i][2], hands[i][3],
                     hands[i][4]);
     }
   }
@@ -83,7 +80,7 @@ BENCHMARK(EvaluateRandomFiveCards);
 
 static void EvaluateRandomSixCards(benchmark::State& state) {
   std::vector<std::vector<int>> hands;
-  CardSampler cs{};
+  card_sampler::CardSampler cs{};
 
   for (int i = 0; i < SIZE; i++) {
     hands.push_back(cs.sample(6));
@@ -91,12 +88,8 @@ static void EvaluateRandomSixCards(benchmark::State& state) {
 
   for (auto _ : state) {
     for (int i = 0; i < SIZE; i++) {
-      EvaluateCards(hands[i][0],
-                    hands[i][1],
-                    hands[i][2],
-                    hands[i][3],
-                    hands[i][4],
-                    hands[i][5]);
+      EvaluateCards(hands[i][0], hands[i][1], hands[i][2], hands[i][3],
+                    hands[i][4], hands[i][5]);
     }
   }
 }
@@ -104,7 +97,7 @@ BENCHMARK(EvaluateRandomSixCards);
 
 static void EvaluateRandomSevenCards(benchmark::State& state) {
   std::vector<std::vector<int>> hands;
-  CardSampler cs{};
+  card_sampler::CardSampler cs{};
 
   for (int i = 0; i < SIZE; i++) {
     hands.push_back(cs.sample(7));
@@ -112,13 +105,8 @@ static void EvaluateRandomSevenCards(benchmark::State& state) {
 
   for (auto _ : state) {
     for (int i = 0; i < SIZE; i++) {
-      EvaluateCards(hands[i][0],
-                    hands[i][1],
-                    hands[i][2],
-                    hands[i][3],
-                    hands[i][4],
-                    hands[i][5],
-                    hands[i][6]);
+      EvaluateCards(hands[i][0], hands[i][1], hands[i][2], hands[i][3],
+                    hands[i][4], hands[i][5], hands[i][6]);
     }
   }
 }

--- a/cpp/benchmark/benchmark_plo4.cc
+++ b/cpp/benchmark/benchmark_plo4.cc
@@ -1,6 +1,6 @@
-#include "phevaluator/phevaluator.h"
 #include "benchmark/benchmark.h"
-#include "card_sampler.h"
+#include "phevaluator/card_sampler.h"
+#include "phevaluator/phevaluator.h"
 
 using namespace phevaluator;
 
@@ -8,7 +8,7 @@ const int SIZE = 100;
 
 static void EvaluateRandomPlo4Cards(benchmark::State& state) {
   std::vector<std::vector<int>> hands;
-  CardSampler cs{};
+  card_sampler::CardSampler cs{};
 
   for (int i = 0; i < SIZE; i++) {
     hands.push_back(cs.sample(9));
@@ -16,14 +16,8 @@ static void EvaluateRandomPlo4Cards(benchmark::State& state) {
 
   for (auto _ : state) {
     for (int i = 0; i < SIZE; i++) {
-      EvaluatePlo4Cards(hands[i][0],
-                        hands[i][1],
-                        hands[i][2],
-                        hands[i][3],
-                        hands[i][4],
-                        hands[i][5],
-                        hands[i][6],
-                        hands[i][7],
+      EvaluatePlo4Cards(hands[i][0], hands[i][1], hands[i][2], hands[i][3],
+                        hands[i][4], hands[i][5], hands[i][6], hands[i][7],
                         hands[i][8]);
     }
   }

--- a/cpp/benchmark/benchmark_plo5.cc
+++ b/cpp/benchmark/benchmark_plo5.cc
@@ -1,15 +1,14 @@
-#include "phevaluator/phevaluator.h"
 #include "benchmark/benchmark.h"
-#include "card_sampler.h"
+#include "phevaluator/card_sampler.h"
+#include "phevaluator/phevaluator.h"
 
 using namespace phevaluator;
-
 
 const int SIZE = 100;
 
 static void EvaluateRandomPlo5Cards(benchmark::State& state) {
   std::vector<std::vector<int>> hands;
-  CardSampler cs{};
+  card_sampler::CardSampler cs{};
 
   for (int i = 0; i < SIZE; i++) {
     hands.push_back(cs.sample(10));
@@ -17,16 +16,9 @@ static void EvaluateRandomPlo5Cards(benchmark::State& state) {
 
   for (auto _ : state) {
     for (int i = 0; i < SIZE; i++) {
-      EvaluatePlo5Cards(hands[i][0],
-                        hands[i][1],
-                        hands[i][2],
-                        hands[i][3],
-                        hands[i][4],
-                        hands[i][5],
-                        hands[i][6],
-                        hands[i][7],
-                        hands[i][8],
-                        hands[i][9]);
+      EvaluatePlo5Cards(hands[i][0], hands[i][1], hands[i][2], hands[i][3],
+                        hands[i][4], hands[i][5], hands[i][6], hands[i][7],
+                        hands[i][8], hands[i][9]);
     }
   }
 }

--- a/cpp/benchmark/benchmark_plo6.cc
+++ b/cpp/benchmark/benchmark_plo6.cc
@@ -1,6 +1,6 @@
-#include "phevaluator/phevaluator.h"
 #include "benchmark/benchmark.h"
-#include "card_sampler.h"
+#include "phevaluator/card_sampler.h"
+#include "phevaluator/phevaluator.h"
 
 using namespace phevaluator;
 
@@ -8,7 +8,7 @@ const int SIZE = 100;
 
 static void EvaluateRandomPlo6Cards(benchmark::State& state) {
   std::vector<std::vector<int>> hands;
-  CardSampler cs{};
+  card_sampler::CardSampler cs{};
 
   for (int i = 0; i < SIZE; i++) {
     hands.push_back(cs.sample(11));
@@ -16,17 +16,9 @@ static void EvaluateRandomPlo6Cards(benchmark::State& state) {
 
   for (auto _ : state) {
     for (int i = 0; i < SIZE; i++) {
-      EvaluatePlo6Cards(hands[i][0],
-                        hands[i][1],
-                        hands[i][2],
-                        hands[i][3],
-                        hands[i][4],
-                        hands[i][5],
-                        hands[i][6],
-                        hands[i][7],
-                        hands[i][8],
-                        hands[i][9],
-                        hands[i][10]);
+      EvaluatePlo6Cards(hands[i][0], hands[i][1], hands[i][2], hands[i][3],
+                        hands[i][4], hands[i][5], hands[i][6], hands[i][7],
+                        hands[i][8], hands[i][9], hands[i][10]);
     }
   }
 }

--- a/cpp/include/phevaluator/card_sampler.h
+++ b/cpp/include/phevaluator/card_sampler.h
@@ -1,38 +1,18 @@
 #pragma once
-#include <algorithm>
 #include <array>
-#include <chrono>
-#include <numeric>
-#include <random>
-#include <set>
 #include <vector>
-
-namespace card_sampler {
-static unsigned seed =
-    std::chrono::system_clock::now().time_since_epoch().count();
-static std::default_random_engine generator(seed);
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+namespace card_sampler {
 class CardSampler {
   std::array<int, 52> deck;
 
  public:
-  CardSampler(void) { std::iota(deck.begin(), deck.end(), 0); }
-  std::vector<int> sample(int size) {
-    std::vector<int> ret;
-    int residual_cards = deck.size();
-    for (int i = 0; i < size; i++) {
-      int target_index = generator() % residual_cards;
-      int tail_index = residual_cards - 1;
-      std::swap(deck[target_index], deck[tail_index]);
-      ret.push_back(deck[tail_index]);
-      residual_cards--;
-    }
-    return ret;
-  }
+  CardSampler(void);
+  std::vector<int> sample(int size);
 };
 }  // namespace card_sampler
 

--- a/cpp/include/phevaluator/card_sampler.h
+++ b/cpp/include/phevaluator/card_sampler.h
@@ -1,20 +1,26 @@
+#pragma once
 #include <algorithm>
-#include <vector>
 #include <array>
-#include <set>
 #include <chrono>
 #include <numeric>
 #include <random>
+#include <set>
+#include <vector>
 
-static unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+namespace card_sampler {
+static unsigned seed =
+    std::chrono::system_clock::now().time_since_epoch().count();
 static std::default_random_engine generator(seed);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 class CardSampler {
   std::array<int, 52> deck;
-public:
-  CardSampler(void) {
-    std::iota(deck.begin(), deck.end(), 0);
-  }
+
+ public:
+  CardSampler(void) { std::iota(deck.begin(), deck.end(), 0); }
   std::vector<int> sample(int size) {
     std::vector<int> ret;
     int residual_cards = deck.size();
@@ -28,3 +34,8 @@ public:
     return ret;
   }
 };
+}  // namespace card_sampler
+
+#ifdef __cplusplus
+}  // closing brace for extern "C"
+#endif

--- a/cpp/src/card_sampler.cc
+++ b/cpp/src/card_sampler.cc
@@ -1,0 +1,30 @@
+#include <phevaluator/card_sampler.h>
+#include <array>
+#include <chrono>
+#include <numeric>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace card_sampler {
+static unsigned seed =
+    std::chrono::system_clock::now().time_since_epoch().count();
+static std::default_random_engine generator(seed);
+
+CardSampler::CardSampler(void) {
+  std::iota(deck.begin(), deck.end(), 0);
+}
+
+std::vector<int> CardSampler::sample(int size) {
+  std::vector<int> ret;
+  int residual_cards = deck.size();
+  for (int i = 0; i < size; i++) {
+    int target_index = generator() % residual_cards;
+    int tail_index = residual_cards - 1;
+    std::swap(deck[target_index], deck[tail_index]);
+    ret.push_back(deck[tail_index]);
+    residual_cards--;
+  }
+  return ret;
+}
+}  // namespace card_sampler

--- a/cpp/test/evaluation_plo4.cc
+++ b/cpp/test/evaluation_plo4.cc
@@ -1,11 +1,11 @@
-#include <cstdio>
-#include <cassert>
-#include <algorithm>
-#include <vector>
-#include <set>
-#include <chrono>
-#include <random>
+#include <phevaluator/card_sampler.h>
 #include <phevaluator/phevaluator.h>
+#include <phevaluator/rank.h>
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "kev/kev_eval.h"
 
@@ -15,54 +15,25 @@ static int percentage(long long numerator, long long denominator) {
   return numerator * 100 / denominator;
 }
 
-static unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-static std::default_random_engine generator(seed);
-static std::uniform_int_distribution<int> distribution(0, 51);
+static card_sampler::CardSampler cs{};
 
-static std::vector<int> RandomCardSample(int size) {
-  std::vector<int> ret;
-  std::set<int> sample;
-
-  while (sample.size() < size) {
-    int number = distribution(generator);
-    if (sample.find(number) == sample.end()) {
-      ret.push_back(number);
-      sample.insert(number);
-    }
-  }
-
-  return ret;
-}
-
-static short IterateKevEval(int a, int b, int c, int d, int e,
-                            int f, int g, int h, int i) {
+static short
+IterateKevEval(int a, int b, int c, int d, int e, int f, int g, int h, int i) {
   short best = 20000;
 
   int board[10][3] = {
-    {a, b, c},
-    {a, b, d},
-    {a, b, e},
-    {a, c, d},
-    {a, c, e},
-    {a, d, e},
-    {b, c, d},
-    {b, c, e},
-    {b, d, e},
-    {c, d, e},
+      {a, b, c}, {a, b, d}, {a, b, e}, {a, c, d}, {a, c, e},
+      {a, d, e}, {b, c, d}, {b, c, e}, {b, d, e}, {c, d, e},
   };
   int hole[6][2] = {
-    {f, g},
-    {f, h},
-    {f, i},
-    {g, h},
-    {g, i},
-    {h, i},
+      {f, g}, {f, h}, {f, i}, {g, h}, {g, i}, {h, i},
   };
 
   for (int j = 0; j < 10; j++) {
     for (int k = 0; k < 6; k++) {
       best = std::min(kev_eval_5cards(board[j][0], board[j][1], board[j][2],
-            hole[k][0], hole[k][1]), best);
+                                      hole[k][0], hole[k][1]),
+                      best);
     }
   }
 
@@ -76,32 +47,21 @@ TEST(EvaluationTest, TestPlo4Cards) {
   std::printf("Start testing Plo4 cards\n");
 
   for (long long count = 0; count < total; count++) {
-    std::vector<int> sample = RandomCardSample(9);
-  
-    int ph_eval = EvaluatePlo4Cards(sample[0],
-                                     sample[1],
-                                     sample[2],
-                                     sample[3],
-                                     sample[4],
-                                     sample[5],
-                                     sample[6],
-                                     sample[7],
-                                     sample[8]).value();
+    std::vector<int> sample = cs.sample(9);
 
-    int kev_eval = IterateKevEval(sample[0],
-                                  sample[1],
-                                  sample[2],
-                                  sample[3],
-                                  sample[4],
-                                  sample[5],
-                                  sample[6],
-                                  sample[7],
-                                  sample[8]);
+    int ph_eval =
+        EvaluatePlo4Cards(sample[0], sample[1], sample[2], sample[3], sample[4],
+                          sample[5], sample[6], sample[7], sample[8])
+            .value();
 
-    EXPECT_EQ(ph_eval, kev_eval) << "Cards are: "
-      << sample[0] << ", " << sample[1] << ", " << sample[2] << ", " << sample[3] << ", "
-      << sample[4] << ", " << sample[5] << ", " << sample[6] << ", " << sample[7] << ", "
-      << sample[8] << ", ";
+    int kev_eval =
+        IterateKevEval(sample[0], sample[1], sample[2], sample[3], sample[4],
+                       sample[5], sample[6], sample[7], sample[8]);
+
+    EXPECT_EQ(ph_eval, kev_eval)
+        << "Cards are: " << sample[0] << ", " << sample[1] << ", " << sample[2]
+        << ", " << sample[3] << ", " << sample[4] << ", " << sample[5] << ", "
+        << sample[6] << ", " << sample[7] << ", " << sample[8] << ", ";
 
     if (percentage(count, total) > progress) {
       progress = percentage(count, total);
@@ -114,4 +74,3 @@ TEST(EvaluationTest, TestPlo4Cards) {
   std::printf("Complete testing Plo4 cards\n");
   std::printf("Tested %lld random hands in total\n", total);
 }
-

--- a/cpp/test/evaluation_plo5.cc
+++ b/cpp/test/evaluation_plo5.cc
@@ -1,11 +1,11 @@
-#include <cstdio>
-#include <cassert>
-#include <algorithm>
-#include <vector>
-#include <set>
-#include <chrono>
-#include <random>
+#include <phevaluator/card_sampler.h>
 #include <phevaluator/phevaluator.h>
+#include <phevaluator/rank.h>
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "kev/kev_eval.h"
 
@@ -15,58 +15,34 @@ static int percentage(long long numerator, long long denominator) {
   return numerator * 100 / denominator;
 }
 
-static unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-static std::default_random_engine generator(seed);
-static std::uniform_int_distribution<int> distribution(0, 51);
+static card_sampler::CardSampler cs{};
 
-static std::vector<int> RandomCardSample(int size) {
-  std::vector<int> ret;
-  std::set<int> sample;
-
-  while (sample.size() < size) {
-    int number = distribution(generator);
-    if (sample.find(number) == sample.end()) {
-      ret.push_back(number);
-      sample.insert(number);
-    }
-  }
-
-  return ret;
-}
-
-static short IterateKevEval(int a, int b, int c, int d, int e,
-                            int f, int g, int h, int i, int j) {
+static short IterateKevEval(int a,
+                            int b,
+                            int c,
+                            int d,
+                            int e,
+                            int f,
+                            int g,
+                            int h,
+                            int i,
+                            int j) {
   short best = 20000;
 
   int board[10][3] = {
-    {a, b, c},
-    {a, b, d},
-    {a, b, e},
-    {a, c, d},
-    {a, c, e},
-    {a, d, e},
-    {b, c, d},
-    {b, c, e},
-    {b, d, e},
-    {c, d, e},
+      {a, b, c}, {a, b, d}, {a, b, e}, {a, c, d}, {a, c, e},
+      {a, d, e}, {b, c, d}, {b, c, e}, {b, d, e}, {c, d, e},
   };
   int hole[10][2] = {
-    {f, g},
-    {f, h},
-    {f, i},
-    {f, j},
-    {g, h},
-    {g, i},
-    {g, j},
-    {h, i},
-    {h, j},
-    {i, j},
+      {f, g}, {f, h}, {f, i}, {f, j}, {g, h},
+      {g, i}, {g, j}, {h, i}, {h, j}, {i, j},
   };
 
   for (int j = 0; j < 10; j++) {
     for (int k = 0; k < 10; k++) {
       best = std::min(kev_eval_5cards(board[j][0], board[j][1], board[j][2],
-            hole[k][0], hole[k][1]), best);
+                                      hole[k][0], hole[k][1]),
+                      best);
     }
   }
 
@@ -80,34 +56,22 @@ TEST(EvaluationTest, TestPlo5Cards) {
   std::printf("Start testing Plo5 cards\n");
 
   for (long long count = 0; count < total; count++) {
-    std::vector<int> sample = RandomCardSample(10);
-  
-    int ph_eval = EvaluatePlo5Cards(sample[0],
-                                    sample[1],
-                                    sample[2],
-                                    sample[3],
-                                    sample[4],
-                                    sample[5],
-                                    sample[6],
-                                    sample[7],
-                                    sample[8],
-                                    sample[9]).value();
+    std::vector<int> sample = cs.sample(10);
 
-    int kev_eval = IterateKevEval(sample[0],
-                                  sample[1],
-                                  sample[2],
-                                  sample[3],
-                                  sample[4],
-                                  sample[5],
-                                  sample[6],
-                                  sample[7],
-                                  sample[8],
-                                  sample[9]);
+    int ph_eval =
+        EvaluatePlo5Cards(sample[0], sample[1], sample[2], sample[3], sample[4],
+                          sample[5], sample[6], sample[7], sample[8], sample[9])
+            .value();
 
-    EXPECT_EQ(ph_eval, kev_eval) << "Cards are: "
-      << sample[0] << ", " << sample[1] << ", " << sample[2] << ", " << sample[3] << ", "
-      << sample[4] << ", " << sample[5] << ", " << sample[6] << ", " << sample[7] << ", "
-      << sample[8] << ", " << sample[9];
+    int kev_eval =
+        IterateKevEval(sample[0], sample[1], sample[2], sample[3], sample[4],
+                       sample[5], sample[6], sample[7], sample[8], sample[9]);
+
+    EXPECT_EQ(ph_eval, kev_eval)
+        << "Cards are: " << sample[0] << ", " << sample[1] << ", " << sample[2]
+        << ", " << sample[3] << ", " << sample[4] << ", " << sample[5] << ", "
+        << sample[6] << ", " << sample[7] << ", " << sample[8] << ", "
+        << sample[9];
 
     if (percentage(count, total) > progress) {
       progress = percentage(count, total);
@@ -120,4 +84,3 @@ TEST(EvaluationTest, TestPlo5Cards) {
   std::printf("Complete testing Plo5 cards\n");
   std::printf("Tested %lld random hands in total\n", total);
 }
-

--- a/cpp/test/evaluation_plo6.cc
+++ b/cpp/test/evaluation_plo6.cc
@@ -1,11 +1,11 @@
-#include <cstdio>
-#include <cassert>
-#include <algorithm>
-#include <vector>
-#include <set>
-#include <chrono>
-#include <random>
+#include <phevaluator/card_sampler.h>
 #include <phevaluator/phevaluator.h>
+#include <phevaluator/rank.h>
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "kev/kev_eval.h"
 
@@ -15,63 +15,35 @@ static int percentage(long long numerator, long long denominator) {
   return numerator * 100 / denominator;
 }
 
-static unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-static std::default_random_engine generator(seed);
-static std::uniform_int_distribution<int> distribution(0, 51);
+static card_sampler::CardSampler cs{};
 
-static std::vector<int> RandomCardSample(int size) {
-  std::vector<int> ret;
-  std::set<int> sample;
-
-  while (sample.size() < size) {
-    int number = distribution(generator);
-    if (sample.find(number) == sample.end()) {
-      ret.push_back(number);
-      sample.insert(number);
-    }
-  }
-
-  return ret;
-}
-
-static short IterateKevEval(int a, int b, int c, int d, int e,
-                            int f, int g, int h, int i, int j, int k) {
+static short IterateKevEval(int a,
+                            int b,
+                            int c,
+                            int d,
+                            int e,
+                            int f,
+                            int g,
+                            int h,
+                            int i,
+                            int j,
+                            int k) {
   short best = 20000;
 
   int board[10][3] = {
-    {a, b, c},
-    {a, b, d},
-    {a, b, e},
-    {a, c, d},
-    {a, c, e},
-    {a, d, e},
-    {b, c, d},
-    {b, c, e},
-    {b, d, e},
-    {c, d, e},
+      {a, b, c}, {a, b, d}, {a, b, e}, {a, c, d}, {a, c, e},
+      {a, d, e}, {b, c, d}, {b, c, e}, {b, d, e}, {c, d, e},
   };
   int hole[15][2] = {
-    {f, g},
-    {f, h},
-    {f, i},
-    {f, j},
-    {f, k},
-    {g, h},
-    {g, i},
-    {g, j},
-    {g, k},
-    {h, i},
-    {h, j},
-    {h, k},
-    {i, j},
-    {i, k},
-    {j, k},
+      {f, g}, {f, h}, {f, i}, {f, j}, {f, k}, {g, h}, {g, i}, {g, j},
+      {g, k}, {h, i}, {h, j}, {h, k}, {i, j}, {i, k}, {j, k},
   };
 
   for (int j = 0; j < 10; j++) {
     for (int k = 0; k < 15; k++) {
       best = std::min(kev_eval_5cards(board[j][0], board[j][1], board[j][2],
-            hole[k][0], hole[k][1]), best);
+                                      hole[k][0], hole[k][1]),
+                      best);
     }
   }
 
@@ -85,36 +57,22 @@ TEST(EvaluationTest, TestPlo6Cards) {
   std::printf("Start testing Plo6 cards\n");
 
   for (long long count = 0; count < total; count++) {
-    std::vector<int> sample = RandomCardSample(11);
-  
-    int ph_eval = EvaluatePlo6Cards(sample[0],
-                                    sample[1],
-                                    sample[2],
-                                    sample[3],
-                                    sample[4],
-                                    sample[5],
-                                    sample[6],
-                                    sample[7],
-                                    sample[8],
-                                    sample[9],
-                                    sample[10]).value();
+    std::vector<int> sample = cs.sample(11);
 
-    int kev_eval = IterateKevEval(sample[0],
-                                  sample[1],
-                                  sample[2],
-                                  sample[3],
-                                  sample[4],
-                                  sample[5],
-                                  sample[6],
-                                  sample[7],
-                                  sample[8],
-                                  sample[9],
-                                  sample[10]);
+    int ph_eval = EvaluatePlo6Cards(sample[0], sample[1], sample[2], sample[3],
+                                    sample[4], sample[5], sample[6], sample[7],
+                                    sample[8], sample[9], sample[10])
+                      .value();
 
-    EXPECT_EQ(ph_eval, kev_eval) << "Cards are: "
-      << sample[0] << ", " << sample[1] << ", " << sample[2] << ", " << sample[3] << ", "
-      << sample[4] << ", " << sample[5] << ", " << sample[6] << ", " << sample[7] << ", "
-      << sample[8] << ", " << sample[9] << ", " << sample[10];
+    int kev_eval = IterateKevEval(sample[0], sample[1], sample[2], sample[3],
+                                  sample[4], sample[5], sample[6], sample[7],
+                                  sample[8], sample[9], sample[10]);
+
+    EXPECT_EQ(ph_eval, kev_eval)
+        << "Cards are: " << sample[0] << ", " << sample[1] << ", " << sample[2]
+        << ", " << sample[3] << ", " << sample[4] << ", " << sample[5] << ", "
+        << sample[6] << ", " << sample[7] << ", " << sample[8] << ", "
+        << sample[9] << ", " << sample[10];
 
     if (percentage(count, total) > progress) {
       progress = percentage(count, total);
@@ -127,4 +85,3 @@ TEST(EvaluationTest, TestPlo6Cards) {
   std::printf("Complete testing Plo6 cards\n");
   std::printf("Tested %lld random hands in total\n", total);
 }
-


### PR DESCRIPTION
This pull request addresses the code duplication of RandomCardSampler between `benchmark_plo*.cc` and the `evaluation_plo*.cc` test files.

The changes include:
* Moving the `CardSampler` class from `benchmark/card_sampler.h` to a new header file `include/phevaluator/card_sampler.h` and source file `src/card_sampler.cc`
* Making `CardSampler` part of the public API by adding it to PUB_HEADERS in CMakeLists.txt
* Updating the `evaluation_plo*.cc` test files to use the `CardSampler` class instead of the local `RandomCardSampler` function
* Cleaning up the test files by removing unused includes

Benefits of these changes:
* Eliminates code duplication of card sampling logic
