### PR TITLE
Format markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ as Omaha poker hands evaluation.
 
 You can install the library using `pip`:
 
-```
+```sh
 pip3 install phevaluator
 ```
 
@@ -129,31 +129,39 @@ and [bensi94](https://github.com/bensi94).
 
 ## Other Implementations
 
-[PHE](https://github.com/thlorenz/phe) is a Javascript port, developed by Thorsten Lorenz.
+[PHE](https://github.com/thlorenz/phe) is a Javascript port, developed by Thorsten
+Lorenz.
 
-[41Poker](https://github.com/41semicolon/41poker) is another Javascript port, developed by 41semicolon.
+[41Poker](https://github.com/41semicolon/41poker) is another Javascript port,
+developed by 41semicolon.
 
 [poker](https://pub.dev/packages/poker) is a Dart port, developed by Kohei.
 
-[ghais/poker](https://github.com/ghais/poker/blob/main/src/Poker/Holdem/Evaluate.hs) contains a Haskell implementation of the evaluator.
+[ghais/poker](https://github.com/ghais/poker/blob/main/src/Poker/Holdem/Evaluate.hs)
+contains a Haskell implementation of the evaluator.
 
 [gophe](https://github.com/mattlangl/gophe) is a Go port, developed by mattlangl.
 
-[poker-handle](https://github.com/pocketberserker/poker-handle/tree/main/src/poker) has a TypeScript port, developed by pocketberserker.
+[poker-handle](https://github.com/pocketberserker/poker-handle/tree/main/src/poker)
+has a TypeScript port, developed by pocketberserker.
 
-[PokerHandEvaluator.cs](https://github.com/travisstaloch/PokerHandEvaluator.cs) is a C# port, developed by travisstaloch.
+[PokerHandEvaluator.cs](https://github.com/travisstaloch/PokerHandEvaluator.cs)
+is a C# port, developed by travisstaloch.
 
-[poker_engine](https://github.com/aleo101/poker_engine) is a Rust port, developed by Alexander Leones.
+[poker_engine](https://github.com/aleo101/poker_engine) is a Rust port,
+developed by Alexander Leones.
 
-[Poker-Calculator](https://github.com/tryabin/Poker-Calculator) contains a CUDA implementation of this evaluator.
+[Poker-Calculator](https://github.com/tryabin/Poker-Calculator) contains a CUDA
+implementation of this evaluator.
 
 ## Awesome Use Cases
 
 ### A simple Hold'em pre-flop equity estimator
 
-A reddit user coded a Hold'em pre-flop equity estimator in C++ using the PHEvaluator library.
+A reddit user coded a Hold'em pre-flop equity estimator in C++ using the
+PHEvaluator library.
 
-https://www.reddit.com/r/poker/comments/okk5qn/i_ran_1m_runouts_of_random_play_to_get_a_sense_of/
+<https://www.reddit.com/r/poker/comments/okk5qn/i_ran_1m_runouts_of_random_play_to_get_a_sense_of/>
 
 The source code can be found in [sim.cc](https://gist.github.com/bwasti/c2ca972c57f4fb581813f82f010c7cb2).
 
@@ -165,10 +173,11 @@ An article about Monte Carlo simulation of Texas Hold'em.
 
 [Estimating the outcome of a Texas hold’em game using Monte Carlo simulation](https://petrosdemetrakopoulos.medium.com/estimating-the-outcome-of-a-texas-holdem-game-using-monte-carlo-simulation-1be35be29036)
 
-It's source code is in https://github.com/petrosDemetrakopoulos/TexasHoldemMonteCarloSimulation
+It's source code is in <https://github.com/petrosDemetrakopoulos/TexasHoldemMonteCarloSimulation>
 
 ## Contributing to this repository
 
-All contributions are welcome. A contribution can be as small as reporting a bug by creating an issue.
+All contributions are welcome. A contribution can be as small as reporting a bug
+by creating an issue.
 
 If you plan to create a Pull Request, please find more details in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -95,7 +95,7 @@ to the rank description table declared in `src/7462.c`.
 The example usage of this library can be found in `examples/c_example.c` and
 `examples/cpp_example.cc`.
 
-#### pheval5, pheval6, and pheval7
+### pheval5, pheval6, and pheval7
 
 The corresponding library files are `libpheval5.a`, `libpheval6.a`, and
 `libpheval7.a`.
@@ -111,7 +111,7 @@ The example usage of these libraries can be found in
 `examples/evaluator6_standalone_example.cc` and
 `examples/evaluator7_standalone_example.cc`.
 
-#### phevalplo4, phevalplo5, and phevalplo6
+### phevalplo4, phevalplo5, and phevalplo6
 
 The corresponding library files are `libphevalplo4.a`, `libphevalplo5.a`, and
 `libphevalplo6.a`.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -5,7 +5,7 @@
 The following intructions assumes you are in the [cpp](/cpp/) directory. If
 you are in the root directory, please change to [cpp](/cpp/) first.
 
-```
+```sh
 cd cpp
 ```
 
@@ -13,7 +13,7 @@ cd cpp
 
 This library can be built using CMake. A recommended way of building it is:
 
-```
+```sh
 mkdir -p build
 cd build
 cmake ..
@@ -25,14 +25,14 @@ a unit test binary `unit_tests`.
 
 Run `unit_tests` to perform the unit tests:
 
-```
+```sh
 ./unit_tests
 ```
 
 Another build option is to build the library only, after generating the CMake files,
 run `make pheval` to build the static-linked library.
 
-```
+```sh
 mkdir -p build
 cd build
 cmake ..
@@ -44,7 +44,7 @@ make pheval
 The unit tests depends on Google Test suite, which isn't available in Windows.
 This way allows us to build the libraries and examples.
 
-```
+```sh
 mkdir -p build
 cd build
 cmake -DBUILD_TESTS=OFF ..
@@ -55,15 +55,15 @@ After successfully running the `cmake` command, each build target will generate 
 
 ### Build with GNU Make
 
-This [cpp](/cpp/) directory also includes a Makefile, for users that want to use native
-GNU Make to compile the library.
+This [cpp](/cpp/) directory also includes a Makefile, for users that want to use
+native GNU Make to compile the library.
 
 Simply run `make` to build the static-linked library `libpheval.a`.
 
 In the [examples](/cpp/examples), there is another Makefile to compile the examples
 with the library linked.
 
-```
+```sh
 cd examples
 make
 ```
@@ -72,7 +72,7 @@ make
 
 After running `make`, you can see the following library files generated:
 
-```
+```text
 libpheval.a      # library pheval
 libpheval5.a     # library pheval5
 libpheval6.a     # library pheval6
@@ -82,7 +82,7 @@ libphevalplo5.a  # library phevalplo5
 libphevalplo6.a  # library phevalplo6
 ```
 
-#### pheval
+### pheval
 
 The corresponding library file is `libpheval.a`.
 
@@ -318,6 +318,7 @@ describe_rank(rank2); // Nines Full over Fours
 ```
 
 <a name="cardid"></a>
+
 ## Card Id
 
 We can use an integer to represent a card. The two least significant bits

--- a/test/README.md
+++ b/test/README.md
@@ -1,14 +1,16 @@
 # Test Data
 
-Each directory has two sets of test data, both in csv format. The last column of each line
-represents the rank of the test case, and the other columns are the card input.
+Each directory has two sets of test data, both in csv format. The last column of
+each line represents the rank of the test case, and the other columns are the
+card input.
 
-In the `string_input_tests.csv` files, the card inputs are using string format, while in the
-`id_input_tests.csv` files, the inputs are [Card Id](../cpp/#cardid) format.
+In the `string_input_tests.csv` files, the card inputs are using string format,
+while in the `id_input_tests.csv` files, the inputs are [Card Id](../cpp/#cardid)
+format.
 
 For example, if we look at the file `five/string_input_tests.csv`, it has six columns.
-The first five columns are the five different cards, and the last column is the rank of the
-given five cards.
+The first five columns are the five different cards, and the last column is the
+rank of the given five cards.
 
 ```bash
 card_1,card_2,card_3,card_4,card_5,rank


### PR DESCRIPTION
With using `markdownlint` and manual fixes.
This is required for #95 as it checks all files.