### PR TITLE
Fix `no-commit-to-branch` hook failure in CI when merging pull requests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   pre-commit:
+    env:
+      SKIP: no-commit-to-branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request addresses an issue where the `no-commit-to-branch` pre-commit hook unexpectedly fails in the GitHub Actions when merging a pull request to specific branches that has already passed CI checks.
https://github.com/HenryRLee/PokerHandEvaluator/actions/runs/8957810302

The root cause is that the `no-commit-to-branch` pre-commit hook is designed to prevent direct commits to protected branches by developers. However, when the GitHub Actions runs on a pull request merge commit, it also triggers all the pre-commit hooks, including `no-commit-to-branch`. 

To resolve this, we can skip the `no-commit-to-branch` hook in the GitHub Actions workflow by setting the environment variable `SKIP=no-commit-to-branch`. This change has been tested in a forked repository and successfully allows the merge to proceed.

Please review and merge this pull request to fix the unexpected behavior of the `no-commit-to-branch` hook during merges in the CI environment.