### PR TITLE
docs: add unified Sphinx site published to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Docs
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "docs/**"
+      - "Documentation/Algorithm.md"
+      - "python/phevaluator/**"
+      - "python/pyproject.toml"
+      - "cpp/README.md"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [develop]
+    paths:
+      - "docs/**"
+      - "Documentation/Algorithm.md"
+      - "python/phevaluator/**"
+      - "python/pyproject.toml"
+      - "cpp/README.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do not cancel in-progress runs so deploys
+# always finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install documentation dependencies
+        run: pip install './python[docs]'
+      - name: Build the HTML documentation
+        run: sphinx-build -b html -W --keep-going docs docs/_build/html
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Only publish from the default branch; PRs just build to catch errors.
+    if: github.ref == 'refs/heads/develop' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 # Editors
 *.swp
 .vscode
+
+# Sphinx documentation build output
+docs/**/_build/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A [Poker Hand Evaluator](https://github.com/HenryRLee/PokerHandEvaluator)
 based on a Perfect Hash Algorithm
 
+📖 Documentation: <https://henryrlee.github.io/PokerHandEvaluator>
+
 ## Overview
 
 Efficiently evaluating a poker hand has been an interesting and challenging

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,19 @@
+# Minimal makefile for Sphinx documentation
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# PokerHandEvaluator documentation
+
+The project documentation is a single [Sphinx](https://www.sphinx-doc.org/)
+site published to GitHub Pages at
+<https://henryrlee.github.io/PokerHandEvaluator> by the
+`.github/workflows/docs.yml` workflow whenever changes land on `develop`.
+
+It is organised into three sections:
+
+- `algorithm/` — the description of the underlying perfect-hash algorithm,
+  included from [`Documentation/Algorithm.md`](../Documentation/Algorithm.md).
+- `cpp/` — usage and examples of the C/C++ library.
+- `python/` — usage and API reference of the `phevaluator` Python package. The
+  API reference is generated from the package's Google-style docstrings.
+
+## Building locally
+
+Install the documentation dependencies (declared in the Python package's
+`docs` optional-dependency group) and build the HTML from this directory:
+
+```shell
+pip install '../python[docs]'
+make html
+```
+
+The generated site is written to `_build/html`. Open `_build/html/index.html`
+in a browser to preview it.
+
+The native `phevaluator._pheval` C extension is mocked during the build (see
+`conf.py`), so no C compiler is required to build the docs.

--- a/docs/algorithm/index.md
+++ b/docs/algorithm/index.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
+
+```{include} ../../Documentation/Algorithm.md
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,101 @@
+"""Sphinx configuration for the PokerHandEvaluator documentation.
+
+This is a single documentation site covering the project as a whole. It is
+organised into three sections:
+
+* ``algorithm`` - the description of the underlying perfect-hash algorithm,
+  sourced from ``Documentation/Algorithm.md``.
+* ``cpp`` - usage and examples of the C/C++ library.
+* ``python`` - usage and API reference of the ``phevaluator`` Python package.
+
+The Python API reference is generated from the package's Google-style
+docstrings via autodoc + napoleon. The native ``phevaluator._pheval`` C
+extension is mocked so the documentation can be built without a C compiler or
+the C sources.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Make the ``phevaluator`` package importable for autodoc. This file lives in
+# ``docs`` at the repository root, so the package is one level up.
+_DOCS_DIR = Path(__file__).parent.resolve()
+_REPO_ROOT = _DOCS_DIR.parent
+_PYTHON_DIR = _REPO_ROOT / "python"
+sys.path.insert(0, str(_PYTHON_DIR))
+
+
+def _read_version() -> str:
+    """Read the package version from the project's ``pyproject.toml``."""
+    text = (_PYTHON_DIR / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if match is None:
+        msg = "Could not find the version in pyproject.toml"
+        raise RuntimeError(msg)
+    return match.group(1)
+
+
+# -- Project information ------------------------------------------------------
+project = "PokerHandEvaluator"
+author = "Henry Lee"
+project_copyright = "2018, Henry Lee"
+release = _read_version()
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "myst_parser",
+]
+
+# The native C extension has no Python source to import, so mock it.
+autodoc_mock_imports = ["phevaluator._pheval"]
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "show-inheritance": True,
+}
+autodoc_typehints = "description"
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+
+# The imported Algorithm.md relies on GitHub-style implicit heading anchors.
+myst_heading_anchors = 4
+
+# Algorithm.md (rendered as-is from the repository) uses in-page links to raw
+# HTML ``<a name="...">`` anchors, which work at runtime (they are emitted
+# verbatim) but cannot be resolved at build time. Silence those warnings
+# instead of editing the canonical source document.
+suppress_warnings = ["myst.xref_missing"]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = "furo"
+html_title = f"PokerHandEvaluator {release}"
+html_static_path = ["_static"]
+
+
+def setup(app):  # noqa: ANN001, ANN201, D103
+    # Algorithm.md uses ``pseudocode`` code fences, which is not a real Pygments
+    # lexer. Register it as plain text so highlighting (and the -W build) works.
+    from pygments.lexers.special import TextLexer
+
+    app.add_lexer("pseudocode", TextLexer)

--- a/docs/cpp/building.rst
+++ b/docs/cpp/building.rst
@@ -1,0 +1,89 @@
+Building and testing
+====================
+
+The following instructions assume you are in the
+`cpp <https://github.com/HenryRLee/PokerHandEvaluator/tree/master/cpp>`_
+directory. If you are in the repository root, change into it first:
+
+.. code-block:: sh
+
+   cd cpp
+
+Build with CMake
+----------------
+
+The library can be built using CMake. A recommended way of building it is:
+
+.. code-block:: sh
+
+   cmake -B build      # create a folder named build and configure the Makefile
+   cmake --build build # start the build in the new folder
+
+This generates a static-linked library ``libpheval.a`` in the new folder, as
+well as a unit test binary ``unit_tests``.
+
+Run ``unit_tests`` to perform the unit tests:
+
+.. code-block:: sh
+
+   cd build/
+   ./unit_tests
+
+Another option is to build the library only, skipping the unit test binary.
+Build with the target ``pheval`` to build just the static-linked library:
+
+.. code-block:: sh
+
+   cmake -B build
+   cmake --build build/ --target pheval
+
+The CMake command generates a Makefile in the new folder, so if you prefer GNU
+Make you can still use it. For example:
+
+.. code-block:: sh
+
+   cmake -B build
+   cd build
+   make pheval
+
+Build on Windows
+----------------
+
+The unit tests depend on the Google Test suite, which isn't available on
+Windows. This option lets you build the libraries and examples without it:
+
+.. code-block:: sh
+
+   cmake -B build -DBUILD_TESTS=OFF
+
+After successfully running the ``cmake`` command, each build target generates a
+``.vcxproj`` file, which is a project file that can be imported into Visual
+Studio.
+
+Build with GNU Make
+-------------------
+
+The ``cpp`` directory also includes a Makefile for users that want to use
+native GNU Make to compile the library.
+
+Simply run ``make`` to build the static-linked library ``libpheval.a``.
+
+In the ``examples`` directory there is another Makefile to compile the examples
+with the library linked:
+
+.. code-block:: sh
+
+   cd examples
+   make
+
+Disabling PLO variants
+----------------------
+
+Building the PLO6 library costs a significant amount of memory. If you don't
+want to build this feature, you may disable PLO6 using a CMake config:
+
+.. code-block:: sh
+
+   cmake -DBUILD_PLO6=OFF .. ; make
+
+Similarly, you can turn off PLO4 and PLO5.

--- a/docs/cpp/card_id.rst
+++ b/docs/cpp/card_id.rst
@@ -1,0 +1,42 @@
+Card Id
+=======================================
+
+We can use an integer to represent a card. The two least significant bits
+represent the 4 suits, ranging from 0-3. The rest of it represents the 13
+ranks, ranging from 0-12.
+
+More specifically, the ranks are:
+
+deuce = 0, trey = 1, four = 2, five = 3, six = 4, seven = 5, eight = 6,
+nine = 7, ten = 8, jack = 9, queen = 10, king = 11, ace = 12.
+
+And the suits are:
+club = 0, diamond = 1, heart = 2, spade = 3
+
+So that you can use ``rank * 4 + suit`` to get the card ID.
+
+Technically, it is fine to swap the suit values, as long as the suits are
+uniquely mapped to the values 0, 1, 2, and 3. If you do swap the suit values,
+make sure to update the mapping in the source code as well (``suitMap`` in
+``include/phevaluator/card.h``).
+
+The complete card Id mapping can be found below. The rows are the ranks from 2
+to Ace, and the columns are the suits: club, diamond, heart and spade.
+
+===  ===  ===  ===  ===
+\      C    D    H    S
+===  ===  ===  ===  ===
+2      0    1    2    3
+3      4    5    6    7
+4      8    9   10   11
+5     12   13   14   15
+6     16   17   18   19
+7     20   21   22   23
+8     24   25   26   27
+9     28   29   30   31
+T     32   33   34   35
+J     36   37   38   39
+Q     40   41   42   43
+K     44   45   46   47
+A     48   49   50   51
+===  ===  ===  ===  ===

--- a/docs/cpp/examples.rst
+++ b/docs/cpp/examples.rst
@@ -1,0 +1,151 @@
+Examples
+========
+
+In this example we use a scenario from the game Texas Hold'em:
+
+Community cards: ``9c 4c 4s 9d 4h`` (both players share these cards)
+
+* Player 1: ``Qc 6c``
+* Player 2: ``2c 9h``
+
+Both players have full houses. Player 1 only has fours full over nines, while
+player 2 has nines full over fours, which is stronger than player 1.
+
+All the code and compiling instructions can be found in the
+`examples <https://github.com/HenryRLee/PokerHandEvaluator/tree/master/cpp/examples>`_
+directory.
+
+Example code in C++
+-------------------
+
+We can construct a ``Card`` by providing a two-character string:
+
+.. code-block:: cpp
+
+   phevaluator::Card a = phevaluator::Card("Qc");
+
+The method ``EvaluateCards`` takes 5 to 7 ``Card`` parameters and returns a
+``Rank``. You can also provide the strings directly and let the ``Card`` values
+be constructed implicitly, to make your code cleaner:
+
+.. code-block:: cpp
+
+   phevaluator::Rank rank1 =
+     phevaluator::EvaluateCards("9c", "4c", "4s", "9d", "4h", "Qc", "6c");
+
+   phevaluator::Rank rank2 =
+     phevaluator::EvaluateCards("9c", "4c", "4s", "9d", "4h", "2c", "9h");
+
+A stronger hand compares as less than a weaker hand:
+
+.. code-block:: cpp
+
+   assert(rank1 > rank2); // rank2 is stronger
+
+We can get the rank value among all 7462 possible hands. This ranking is
+identical to the return value of Cactus Kev's evaluator: the best rank has
+value 1 (a Royal Straight Flush), while the worst rank is 7462.
+
+.. code-block:: cpp
+
+   int value1 = rank1.value(); // 292
+   int value2 = rank2.value(); // 236
+
+We can tell the ranking category of the rank, either using the method
+``category`` (which returns an enumerator) or ``describeCategory`` (which
+returns a string). In this example both players hold full houses:
+
+.. code-block:: cpp
+
+   assert(rank1.category() == FULL_HOUSE);
+   assert(rank1.describeCategory() == "Full House");
+
+   assert(rank2.category() == FULL_HOUSE);
+   assert(rank2.describeCategory() == "Full House");
+
+We can get more detail from the rank using ``describeRank`` or
+``describeSampleHand``. The best 5-card hand from player 2 is 9-9-9-4-4:
+
+.. code-block:: cpp
+
+   assert(rank2.describeSampleHand() == "99944");
+
+Suit information is missing from that method because it usually doesn't matter,
+unless all five cards share the same suit. The ``isFlush`` method tells us
+whether the sample hand is a flush. In this example it is not:
+
+.. code-block:: cpp
+
+   assert(!rank2.isFlush());
+
+Finally, ``describeRank`` gives a short description of the sample hand:
+
+.. code-block:: cpp
+
+   assert(rank2.describeRank() == "Nines Full over Fours");
+
+Example code in C
+-----------------
+
+In the C version the evaluation is trickier, since we have to convert each card
+to an integer ourselves. The formula is ``rank * 4 + suit``. See :doc:`card_id`
+for the full mapping.
+
+.. code-block:: c
+
+   // Community cards
+   int a = 7 * 4 + 0; // 9c
+   int b = 2 * 4 + 0; // 4c
+   int c = 2 * 4 + 3; // 4s
+   int d = 7 * 4 + 1; // 9d
+   int e = 2 * 4 + 2; // 4h
+
+   // Player 1
+   int f = 10 * 4 + 0; // Qc
+   int g = 4 * 4 + 0; // 6c
+
+   // Player 2
+   int h = 0 * 4 + 0; // 2c
+   int i = 7 * 4 + 2; // 9h
+
+After constructing all the cards, use ``evaluate_7cards`` to get a rank value.
+The best rank is 1 (a Royal Straight Flush) and the worst is 7462:
+
+.. code-block:: c
+
+   int rank1 = evaluate_7cards(a, b, c, d, e, f, g); // 292
+   int rank2 = evaluate_7cards(a, b, c, d, e, h, i); // 236
+
+When comparing two rank values, the smaller one is stronger:
+
+.. code-block:: c
+
+   assert(rank1 > rank2); // rank2 is stronger
+
+Similar to the C++ interface, we can get the rank category:
+
+.. code-block:: c
+
+   enum rank_category category = get_rank_category(rank1);
+   assert(category == FULL_HOUSE);
+
+   const char *categoryDesc = describe_rank_category(category); // "Full House"
+
+Or get the sample hand from the rank:
+
+.. code-block:: c
+
+   describe_sample_hand(rank2); // 9 9 9 4 4
+
+Although suit information is missing here, we only care about whether all five
+cards are the same suit. Check it using ``is_flush``:
+
+.. code-block:: c
+
+   is_flush(rank2); // false
+
+Finally, ``describe_rank`` gives a short description of the rank:
+
+.. code-block:: c
+
+   describe_rank(rank2); // Nines Full over Fours

--- a/docs/cpp/index.rst
+++ b/docs/cpp/index.rst
@@ -1,0 +1,18 @@
+C/C++
+=====
+
+This section documents the C/C++ library in the
+`cpp <https://github.com/HenryRLee/PokerHandEvaluator/tree/master/cpp>`_
+directory of the repository. It offers evaluation of 5-card, 6-card, and
+7-card hands, as well as Omaha poker hands (PLO4, PLO5, and PLO6).
+
+The library is the reference implementation of the perfect-hash algorithm
+described in the :doc:`../algorithm/index` section.
+
+.. toctree::
+   :maxdepth: 2
+
+   building
+   usage
+   examples
+   card_id

--- a/docs/cpp/usage.rst
+++ b/docs/cpp/usage.rst
@@ -1,0 +1,67 @@
+Using the libraries
+===================
+
+After running ``make``, the following library files are generated:
+
+.. code-block:: text
+
+   libpheval.a      # library pheval
+   libpheval5.a     # library pheval5
+   libpheval6.a     # library pheval6
+   libpheval7.a     # library pheval7
+   libphevalplo4.a  # library phevalplo4
+   libphevalplo5.a  # library phevalplo5
+   libphevalplo6.a  # library phevalplo6
+
+pheval
+------
+
+The corresponding library file is ``libpheval.a``.
+
+This library includes the 5-card, 6-card, and 7-card evaluators. It also
+includes all the methods of describing a rank. However, the additional memory
+usage of these rank-describing methods is significantly high (356k), due to the
+rank description table declared in ``src/7462.c``.
+
+The example usage of this library can be found in ``examples/c_example.c`` and
+``examples/cpp_example.cc`` (see :doc:`examples`).
+
+pheval5, pheval6, and pheval7
+-----------------------------
+
+The corresponding library files are ``libpheval5.a``, ``libpheval6.a``, and
+``libpheval7.a``.
+
+These libraries are memory-optimized for evaluating 5-card hands, 6-card hands,
+and 7-card hands respectively. They don't include the rank-describing methods,
+in order to save memory usage.
+
+The example usage of these libraries can be found in
+``examples/evaluator5_standalone_example.cc``,
+``examples/evaluator6_standalone_example.cc``, and
+``examples/evaluator7_standalone_example.cc``.
+
+phevalplo4, phevalplo5, and phevalplo6
+--------------------------------------
+
+The corresponding library files are ``libphevalplo4.a``, ``libphevalplo5.a``,
+and ``libphevalplo6.a``.
+
+These libraries evaluate Pot Limit Omaha 4 (standard Omaha) hands, Pot Limit
+Omaha 5 hands, and Pot Limit Omaha 6 hands respectively. They also include all
+the methods of describing a rank; the additional memory usage is insignificant
+compared to the memory usage of the basic Omaha evaluators.
+
+The example usage of these libraries can be found in ``examples/plo4_example.cc``,
+``examples/plo5_example.cc``, and ``examples/plo6_example.cc``.
+
+Linking the library
+-------------------
+
+After building the libraries, add the ``./include`` directory to your includes
+path, and link the library to your source code. At least the C++11 standard is
+required for compiling. For example:
+
+.. code-block:: sh
+
+   g++ -I include/ -std=c++11 your_source_code.cc libpheval.a -o your_binary

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,33 @@
+PokerHandEvaluator
+==================
+
+`PokerHandEvaluator <https://github.com/HenryRLee/PokerHandEvaluator>`_ (PH
+Evaluator) is an efficient poker hand evaluator based on a perfect hash
+algorithm. Instead of traversing all the combinations, it looks up the hand
+strength from a pre-computed hash table, which only costs very few CPU cycles
+and a considerably small amount of memory (~100kb for the 7-card evaluation).
+With slight modifications the same algorithm is also applied to evaluating
+Omaha and Pot Limit Omaha hands.
+
+This site is organised into three sections:
+
+* :doc:`algorithm/index` - the description of the underlying perfect-hash
+  algorithm.
+* :doc:`cpp/index` - usage and examples of the C/C++ library.
+* :doc:`python/index` - usage and API reference of the ``phevaluator`` Python
+  package.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   algorithm/index
+   cpp/index
+   python/index
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,22 +5,22 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
+    set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
-	echo.
-	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
-	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
-	echo.may add the Sphinx directory to PATH.
-	echo.
-	echo.If you don't have Sphinx installed, grab it from
-	echo.https://www.sphinx-doc.org/
-	exit /b 1
+    echo.
+    echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+    echo.installed, then set the SPHINXBUILD environment variable to point
+    echo.to the full path of the 'sphinx-build' executable. Alternatively you
+    echo.may add the Sphinx directory to PATH.
+    echo.
+    echo.If you don't have Sphinx installed, grab it from
+    echo.https://www.sphinx-doc.org/
+    exit /b 1
 )
 
 if "%1" == "" goto help

--- a/docs/python/api.rst
+++ b/docs/python/api.rst
@@ -1,0 +1,26 @@
+API reference
+=============
+
+Card evaluation
+---------------
+
+.. automodule:: phevaluator.evaluator
+   :members:
+
+Omaha / Pot Limit Omaha evaluation
+----------------------------------
+
+.. automodule:: phevaluator.evaluator_omaha
+   :members:
+
+Card
+----
+
+.. automodule:: phevaluator.card
+   :members:
+
+Utilities
+---------
+
+.. automodule:: phevaluator.utils
+   :members:

--- a/docs/python/card_id.rst
+++ b/docs/python/card_id.rst
@@ -1,0 +1,42 @@
+Card Id
+=======================================
+
+We can use an integer to represent a card. The two least significant bits
+represent the 4 suits, ranging from 0-3. The rest of it represents the 13
+ranks, ranging from 0-12.
+
+More specifically, the ranks are:
+
+deuce = 0, trey = 1, four = 2, five = 3, six = 4, seven = 5, eight = 6,
+nine = 7, ten = 8, jack = 9, queen = 10, king = 11, ace = 12.
+
+And the suits are:
+club = 0, diamond = 1, heart = 2, spade = 3
+
+So that you can use ``rank * 4 + suit`` to get the card ID.
+
+Technically, it is fine to swap the suit values, as long as the suits are
+uniquely mapped to the values 0, 1, 2, and 3. If you do swap the suit values,
+make sure to update the mapping in the source code as well (``suit_map`` in
+``phevaluator/card.py``).
+
+The complete card Id mapping can be found below. The rows are the ranks from 2
+to Ace, and the columns are the suits: club, diamond, heart and spade.
+
+===  ===  ===  ===  ===
+\      C    D    H    S
+===  ===  ===  ===  ===
+2      0    1    2    3
+3      4    5    6    7
+4      8    9   10   11
+5     12   13   14   15
+6     16   17   18   19
+7     20   21   22   23
+8     24   25   26   27
+9     28   29   30   31
+T     32   33   34   35
+J     36   37   38   39
+Q     40   41   42   43
+K     44   45   46   47
+A     48   49   50   51
+===  ===  ===  ===  ===

--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -1,0 +1,18 @@
+Python
+======
+
+This section documents the ``phevaluator`` Python package. The source lives in
+the `python <https://github.com/HenryRLee/PokerHandEvaluator/tree/master/python>`_
+directory of the repository.
+
+The package is a thin Python layer over the same C implementation used by the
+C/C++ library, so it shares the perfect-hash algorithm described in the
+:doc:`../algorithm/index` section.
+
+.. toctree::
+   :maxdepth: 2
+
+   installation
+   usage
+   card_id
+   api

--- a/docs/python/installation.rst
+++ b/docs/python/installation.rst
@@ -1,0 +1,45 @@
+Installation
+============
+
+The library requires Python 3.10 or newer.
+
+The evaluator is implemented as a C extension (``phevaluator._pheval``) that
+wraps the C sources in the repository's
+`cpp <https://github.com/HenryRLee/PokerHandEvaluator/tree/master/cpp>`_
+directory, so a C compiler and **pip 21.3 or newer** are required to build from
+source.
+
+From PyPI
+---------
+
+.. code-block:: shell
+
+   pip install phevaluator
+
+From source
+-----------
+
+Build from within the repository (the sibling ``cpp`` directory is used to
+compile the extension):
+
+.. code-block:: shell
+
+   pip install .
+
+Optional Pot Limit Omaha support
+---------------------------------
+
+``evaluate_plo5_cards`` and ``evaluate_plo6_cards`` require the package to be
+built with PLO5/PLO6 support. Their lookup tables are very large (hundreds of MB
+of generated C source each), so they are **opt-in**: set the
+``PHEVALUATOR_BUILD_PLO`` environment variable when installing from the
+repository.
+
+.. code-block:: shell
+
+   # Build with PLO5 and PLO6 support (also accepts "5", "6", or "all")
+   PHEVALUATOR_BUILD_PLO=5,6 pip install .
+
+Calling ``evaluate_plo5_cards`` / ``evaluate_plo6_cards`` on a package built
+without the corresponding support raises :class:`NotImplementedError`.
+``evaluate_plo4_cards`` (and ``evaluate_omaha_cards``) are always available.

--- a/docs/python/usage.rst
+++ b/docs/python/usage.rst
@@ -1,0 +1,48 @@
+Usage
+=====
+
+Evaluating a hand
+-----------------
+
+The main function is :func:`phevaluator.evaluate_cards`.
+
+.. code-block:: python
+
+   from phevaluator import evaluate_cards
+
+   p1 = evaluate_cards("9c", "4c", "4s", "9d", "4h", "Qc", "6c")
+   p2 = evaluate_cards("9c", "4c", "4s", "9d", "4h", "2c", "9h")
+
+   # The rank is an integer from 1 (strongest) to 7462 (weakest), so a
+   # smaller value means a stronger hand. Player 2 has a stronger hand here.
+   print(f"The rank of the hand in player 1 is {p1}")  # 292
+   print(f"The rank of the hand in player 2 is {p2}")  # 236
+
+The returned value is the rank of the hand among all 7462 distinct five-card
+hands. It is identical to the return value of Cactus Kev's evaluator: ``1`` is
+the best possible hand (a Royal Straight Flush) and ``7462`` is the worst. A
+smaller value is always a stronger hand, so you can compare two hands directly
+(e.g. ``p2 < p1`` means player 2 wins).
+
+The function accepts both integer card ids and card strings (with a format like
+``"Ah"`` or ``"2C"``). The number of cards must be between 5 and 7.
+
+Omaha and Pot Limit Omaha
+-------------------------
+
+Omaha-style hands (five community cards followed by the hole cards) can be
+evaluated with the dedicated functions:
+
+.. code-block:: python
+
+   from phevaluator import evaluate_omaha_cards  # 4 hole cards
+   from phevaluator import evaluate_plo4_cards   # 4 hole cards (alias of Omaha)
+   from phevaluator import evaluate_plo5_cards   # 5 hole cards
+   from phevaluator import evaluate_plo6_cards   # 6 hole cards
+
+   # 5 community cards + 4 hole cards. The return value is a rank in the same
+   # 1 (strongest) to 7462 (weakest) scale as evaluate_cards, computed from the
+   # best five-card hand allowed by the Omaha rules.
+   evaluate_omaha_cards("4c", "5c", "6c", "7s", "8s", "2c", "9c", "As", "Kd")
+
+See :doc:`installation` for how to enable the opt-in PLO5/PLO6 evaluators.

--- a/python/README.md
+++ b/python/README.md
@@ -15,6 +15,9 @@ considerably small memory (~100kb for the 7 card evaluation). With slight
 modification, the same algorithm can be also applied to evaluating Omaha
 poker hands.
 
+The full API documentation is published at
+<https://henryrlee.github.io/PokerHandEvaluator/python>.
+
 ## Installation
 
 The library requires Python 3.10 or newer.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,9 +36,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/HenryRLee/PokerHandEvaluator"
-# TODO(@azriel1rf): Add a link to documentation for Python after it's published
-# https://github.com/HenryRLee/PokerHandEvaluator/issues/105
-Documentation = "https://github.com/HenryRLee/PokerHandEvaluator/tree/master/Documentation"
+Documentation = "https://henryrlee.github.io/PokerHandEvaluator/python"
 Repository = "https://github.com/HenryRLee/PokerHandEvaluator"
 Issues = "https://github.com/HenryRLee/PokerHandEvaluator/issues"
 # TODO(@azriel1rf): Add a link to the changelog after it's published
@@ -51,6 +49,11 @@ dev = [
     "mypy",
     "ruff",
     "twine",
+]
+docs = [
+    "sphinx",
+    "furo",
+    "myst-parser",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Closes #105.

Publishes the project documentation as a single Sphinx site to GitHub Pages at **https://henryrlee.github.io/PokerHandEvaluator**, organised into three sections.

## What's included

- **`docs/`** — one unified Sphinx project (furo theme, autodoc + napoleon, myst-parser):
  - **algorithm/** — includes the existing `Documentation/Algorithm.md` verbatim via MyST `{include}` (single source of truth, file unchanged).
  - **cpp/** — `building`, `usage`, `examples`, `card_id` pages documenting the C/C++ library (derived from `cpp/README.md`).
  - **python/** — `installation`, `usage`, `card_id`, plus an autodoc API reference generated from the `phevaluator` docstrings (the native `_pheval` C extension is mocked, so no compiler is needed to build docs).
- **`.github/workflows/docs.yml`** — builds with `sphinx-build -W` (warnings as errors). PRs build to catch errors; only `develop` (the default branch) deploys to Pages.
- **`python/pyproject.toml`** — adds a `docs` optional-dependency group and sets the `Documentation` URL to the published `/python` section.
- Root `README.md` gains a documentation link; `.gitignore` ignores `docs/**/_build/`.

## Notes

- `conf.py` registers a `pseudocode` plain-text lexer and suppresses only the `myst.xref_missing` warnings from Algorithm.md's GitHub-style `<a name>` anchors, so the `-W` build stays clean **without editing the canonical algorithm doc**. The anchors still work at runtime.
- Verified locally with a clean-room `sphinx-build -W` build (exit 0, no warnings); all three section indexes and the Python API render correctly.

## Action required before merge

Set **Settings → Pages → Source: GitHub Actions** so the deploy job can publish.
