### PR TITLE
Bump version to 0.6.0 and add a changelog

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -8,3 +8,9 @@ MD033:
   #   [Go to section](#section)
   #   <a name="section"></a>
   allowed_elements: [a]
+
+# MD024 - Multiple headings with the same content
+MD024:
+  # Allow identical headings as long as they are not siblings. Changelogs
+  # naturally repeat section headings (e.g. "Python") under each version.
+  siblings_only: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.6.0] - Unreleased
+
+### C/C++
+
+- Added PLO5 and PLO6 evaluators.
+- Fixed a bug in the C++ hand (`Rank`) comparison operators.
+- Removed the `Hand` class (`phevaluator/hand.h` header) and the `EvaluateHand`
+  function.
+
+New public functions and types:
+
+- C:
+  - `evaluate_plo4_cards` (alias of `evaluate_omaha_cards`)
+  - `evaluate_plo5_cards`
+  - `evaluate_plo6_cards`
+- C++:
+  - `EvaluatePlo4Cards` (alias of `EvaluateOmahaCards`)
+  - `EvaluatePlo5Cards`
+  - `EvaluatePlo6Cards`
+
+Removed public functions and types:
+
+- C++: `EvaluateHand`, `Hand` class.
+
+### Python
+
+- Evaluation code is now backed by the C-compiled library.
+- Added PLO5 and PLO6 evaluation.
+- Supported Python versions changed to Python 3.10 - 3.14.
+
+New public functions:
+
+- `evaluate_5cards`
+- `evaluate_6cards`
+- `evaluate_7cards`
+- `evaluate_plo4_cards` (alias of `evaluate_omaha_cards`)
+- `evaluate_plo5_cards`
+- `evaluate_plo6_cards`
+
+## [0.5.3.1] - 2024-03-21
+
+### Python
+
+- Update the example usage in README.md and the website.
+
+## [0.5.3] - 2024-03-14
+
+### Python
+
+- Separate package to improve memory usage.
+
+## [0.5.2] - 2023-03-10
+
+### Python
+
+- Fix the hint of list type in Python 3.7.
+
+## [0.5.1] - 2022-04-22
+
+### Python
+
+- Fix package not containing entire codes and omaha data.
+
+## [0.5.0.4] - 2021-10-31
+
+### Python
+
+- Fix package not containing entire codes and omaha data.
+
+## [0.5.0] - 2021-10-19
+
+### Python
+
+- Remove Omaha hand evaluation from method `evaluate_cards`.
+- Remove methods `evaluate_5cards`, `evaluate_6cards` and `evaluate_7cards`.
+
+## [0.4.0.3] - 2021-10-18
+
+### Python
+
+- Build with setuptools.
+
+## [0.4.0.2] - 2021-10-16
+
+### Python
+
+- Create PyPI package phevaluator.
+
+## [0.4.0.1] - 2021-10-11
+
+### Python
+
+- New source code structure and packaging methods (no functional changes).
+
+## [0.4.0] - 2021-10-06
+
+### C/C++
+
+- Add `describeCard`, `describeSuit`, and `describeRank` methods for `Card`.
+- Change `describeSampleHand` to return a string with no space delimiters.
+
+### Python
+
+- Remove 8-card and 9-card evaluations.
+- Add Omaha evaluation.
+- Add `describe_rank`, `describe_suit`, and `describe_card` for the Card class.
+- Fix and improve the `table_tests` scripts.
+
+### Misc
+
+- Use GitHub workflow as CI.
+
+## [0.3.1] - 2020-05-25
+
+### C/C++
+
+- Use O3 optimization.
+
+## [0.3.0] - 2020-05-24
+
+### C/C++
+
+- Add evaluation for Omaha hands.
+
+## [0.2.0] - 2019-11-25
+
+### C++
+
+- Add Hand and Rank types.
+- Add the `EvaluateHand` method.
+- Add multiple methods to describe a Rank.
+
+### C
+
+- Add multiple methods to describe a Rank.
+- Add the 7462 table.
+
+### Python
+
+- Refactor the table test code.
+
+## [0.1.0] - 2019-11-20
+
+- Supports Poker Hand Evaluation from 5 to 9 cards.
+- Supports C, C++ and Python languages.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
+
+```{include} ../CHANGELOG.md
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ This site is organised into three sections:
 * :doc:`cpp/index` - usage and examples of the C/C++ library.
 * :doc:`python/index` - usage and API reference of the ``phevaluator`` Python
   package.
+* :doc:`changelog` - the history of notable changes across releases.
 
 .. toctree::
    :maxdepth: 2
@@ -24,6 +25,7 @@ This site is organised into three sections:
    algorithm/index
    cpp/index
    python/index
+   changelog
 
 Indices and tables
 ==================

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phevaluator"
-version = "0.5.3.1"
+version = "0.6.0"
 requires-python = ">=3.10, <4"
 authors = [
     {name = "Henry Lee", email = "lee0906@hotmail.com"}


### PR DESCRIPTION
Closes #106

## Summary

Prepares the 0.6.0 release.

- Bumps the Python package version to `0.6.0` in `python/pyproject.toml` (the C/C++ `CMakeLists.txt` was already at `0.6.0`). The Sphinx docs pick up the version automatically from `pyproject.toml`.
- Adds a root `CHANGELOG.md` documenting every released version (0.1.0 → 0.5.3.1), with descriptions sourced from the git tag messages, plus a `0.6.0` entry.
- Surfaces the changelog in the documentation site: `docs/changelog.md` includes the root `CHANGELOG.md`, and it is added to the `toctree` in `docs/index.rst`.

### 0.6.0 highlights

**C/C++**
- Added PLO5 and PLO6 evaluators.
- Fixed a bug in the C++ hand (`Rank`) comparison operators.
- Removed the `Hand` class (`phevaluator/hand.h`) and `EvaluateHand`.

**Python**
- Evaluation code is now backed by the C-compiled library.
- Added PLO5 and PLO6 evaluation.
- Supported Python versions changed to 3.10 - 3.14.

## Testing

- `sphinx-build -b html -W docs docs/_build/html` — builds cleanly (warnings-as-errors), and the new changelog page renders.
