### PR TITLE
Add gated PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -96,9 +96,7 @@ jobs:
           TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
         run: |
           python -m pip install --upgrade twine
-          # --skip-existing lets the workflow be re-run without failing if this
-          # version was already uploaded to PyPI.
-          twine upload --skip-existing dist/*
+          twine upload dist/*
 
   test:
     name: Test PyPI package (py ${{ matrix.python-version }})

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,10 +2,13 @@ name: Publish to PyPI
 
 # Manually triggered release of the Python package to PyPI. It mirrors the
 # TestPyPI workflow (build an sdist, upload it with twine, then install the
-# published package and run the test suite against it), but it is gated twice:
-#   * only repository maintainers/admins may run it, and
+# published package and run the test suite against it), but the release is
+# guarded by several gates:
+#   * only repository maintainers/admins may run it,
 #   * it only proceeds if the "Publish to TestPyPI" workflow has already
-#     succeeded for the exact same commit.
+#     succeeded for the exact same commit, and
+#   * the upload runs in the protected 'pypi' GitHub Environment, so a required
+#     reviewer must approve it (configured in the repository settings).
 # This makes TestPyPI a mandatory rehearsal for every PyPI release.
 #
 # Requires a repository secret named PYPI_API_TOKEN holding a PyPI API token
@@ -100,6 +103,13 @@ jobs:
     name: Upload to PyPI
     needs: build
     runs-on: ubuntu-latest
+    # Gated by the 'pypi' GitHub Environment. Configure it in the repository
+    # settings (Settings -> Environments -> pypi) with Required reviewers so a
+    # maintainer must approve before the upload runs. The PYPI_API_TOKEN secret
+    # may also be scoped to this environment for extra isolation.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/phevaluator/
     steps:
       - name: Download the distribution artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,149 @@
+name: Publish to PyPI
+
+# Manually triggered release of the Python package to PyPI. It mirrors the
+# TestPyPI workflow (build an sdist, upload it with twine, then install the
+# published package and run the test suite against it), but it is gated: it
+# only proceeds if the "Publish to TestPyPI" workflow has already succeeded for
+# the exact same commit. This makes TestPyPI a mandatory rehearsal for every
+# PyPI release.
+#
+# Requires a repository secret named PYPI_API_TOKEN holding a PyPI API token
+# (https://pypi.org/manage/account/token/).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  verify-testpypi:
+    name: Require a successful TestPyPI release for this commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a successful TestPyPI run on this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Count successful runs of the TestPyPI workflow for this exact commit.
+          count=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/publish-testpypi.yml/runs?head_sha=${GITHUB_SHA}&per_page=100" \
+            --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')
+          echo "Successful TestPyPI runs for ${GITHUB_SHA}: ${count:-0}"
+          if [ "${count:-0}" -lt 1 ]; then
+            echo "::error::No successful 'Publish to TestPyPI' run found for commit ${GITHUB_SHA}. Run and pass the TestPyPI workflow on this commit before releasing to PyPI."
+            exit 1
+          fi
+
+  build:
+    name: Build distribution
+    needs: verify-testpypi
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Read package version
+        id: version
+        run: |
+          version=$(grep -m1 '^version' python/pyproject.toml \
+            | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Building phevaluator ${version}"
+
+      - name: Build the source distribution
+        # Only an sdist is published: the PLO4/Omaha + 5/6/7-card base package
+        # builds quickly from source on any platform. PLO5/PLO6 remain an
+        # opt-in local build (PHEVALUATOR_BUILD_PLO) and are not distributed.
+        run: |
+          cd python
+          python -m pip install --upgrade build twine
+          python -m build --sdist
+          twine check dist/*
+
+      - name: Upload the distribution artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pypi-dist
+          path: python/dist/*
+
+  publish:
+    name: Upload to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the distribution artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: pypi-dist
+          path: dist
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Upload with twine
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+        run: |
+          python -m pip install --upgrade twine
+          # --skip-existing lets the workflow be re-run without failing if this
+          # version was already uploaded to PyPI.
+          twine upload --skip-existing dist/*
+
+  test:
+    name: Test PyPI package (py ${{ matrix.python-version }})
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      # The test suite and its CSV fixtures (test_data/) live in the repository,
+      # so it is checked out even though phevaluator itself is installed from
+      # PyPI.
+      - uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install phevaluator from PyPI
+        # The exact version pin ensures the freshly published release is fetched.
+        # Retries cover index propagation delay right after the upload.
+        run: |
+          version="${{ needs.build.outputs.version }}"
+          for attempt in 1 2 3 4 5 6; do
+            if python -m pip install "phevaluator==${version}"; then
+              echo "Installed phevaluator ${version} from PyPI"
+              exit 0
+            fi
+            echo "phevaluator ${version} not available yet; retrying in 15s..."
+            sleep 15
+          done
+          echo "Failed to install phevaluator ${version} from PyPI" >&2
+          exit 1
+
+      - name: Run the test suite against the installed package
+        # The tests are staged into a directory that does not contain the
+        # phevaluator source tree, so imports resolve to the package installed
+        # from PyPI rather than the local checkout. The layout mirrors the
+        # repository (python/tests + test_data) so the fixtures resolve.
+        run: |
+          staging="${RUNNER_TEMP}/pkgtest"
+          mkdir -p "${staging}/python"
+          cp -r python/tests "${staging}/python/tests"
+          cp -r test_data "${staging}/test_data"
+          cd "${staging}/python"
+          python -m unittest discover -v

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,10 +2,11 @@ name: Publish to PyPI
 
 # Manually triggered release of the Python package to PyPI. It mirrors the
 # TestPyPI workflow (build an sdist, upload it with twine, then install the
-# published package and run the test suite against it), but it is gated: it
-# only proceeds if the "Publish to TestPyPI" workflow has already succeeded for
-# the exact same commit. This makes TestPyPI a mandatory rehearsal for every
-# PyPI release.
+# published package and run the test suite against it), but it is gated twice:
+#   * only repository maintainers/admins may run it, and
+#   * it only proceeds if the "Publish to TestPyPI" workflow has already
+#     succeeded for the exact same commit.
+# This makes TestPyPI a mandatory rehearsal for every PyPI release.
 #
 # Requires a repository secret named PYPI_API_TOKEN holding a PyPI API token
 # (https://pypi.org/manage/account/token/).
@@ -17,6 +18,28 @@ permissions:
   actions: read
 
 jobs:
+  authorize:
+    name: Authorize maintainer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the actor to be a repository maintainer or admin
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # workflow_dispatch already requires write access, but publishing the
+          # official package is restricted further to maintainers/admins.
+          role=$(gh api \
+            "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+            --jq '.role_name // .permission')
+          echo "Actor '${{ github.actor }}' has role '${role}'."
+          case "${role}" in
+            admin|maintain)
+              echo "Authorized to publish to PyPI." ;;
+            *)
+              echo "::error::Publishing to PyPI is restricted to repository maintainers and admins (actor '${{ github.actor }}' has role '${role}')."
+              exit 1 ;;
+          esac
+
   verify-testpypi:
     name: Require a successful TestPyPI release for this commit
     runs-on: ubuntu-latest
@@ -37,7 +60,7 @@ jobs:
 
   build:
     name: Build distribution
-    needs: verify-testpypi
+    needs: [authorize, verify-testpypi]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Adds a **manually triggered** (`workflow_dispatch`) workflow that releases the Python package to **PyPI**, mirroring the TestPyPI workflow but with multiple release gates.

## Jobs

1. **authorize** — checks the triggering actor's repository role via the GitHub API and only proceeds for **admins/maintainers**.
2. **verify-testpypi** — requires a `publish-testpypi.yml` run with `head_sha == github.sha` and a `success` conclusion, so PyPI can't be released until TestPyPI has passed **for that exact commit**.
3. **build** (`needs: [authorize, verify-testpypi]`) — builds the sdist and runs `twine check`.
4. **publish** — runs in the protected **`pypi` GitHub Environment** (required-reviewer approval) and uploads with `twine upload` (no `--skip-existing`, so re-releasing an existing version fails loudly).
5. **test** — installs the freshly published package **from PyPI** and runs the test suite across Python 3.10–3.14.

## Release gates (defense in depth)

- **Maintainers only** — the `authorize` job (workflow-enforced).
- **TestPyPI rehearsal** — the `verify-testpypi` job (same commit must have passed TestPyPI).
- **Manual approval** — the `pypi` environment (platform-enforced; a required reviewer must approve the upload).

## Required setup (one-time, in repository settings)

1. Add a repository secret **`PYPI_API_TOKEN`** with a PyPI API token (https://pypi.org/manage/account/token/). It can optionally be scoped to the `pypi` environment.
2. Create an environment named **`pypi`** under *Settings → Environments* and add the maintainers as **Required reviewers** (optionally restrict it to protected branches).

## Notes

- Same design as the TestPyPI workflow: sdist-only, version read from `pyproject.toml`, retry loop for index propagation.
