### PR TITLE
Fix cibuildwheel tag in PyPI workflow (v3 -> v4.1.0)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -124,7 +124,7 @@ jobs:
           tar -xzf dist/*.tar.gz -C sdist-src --strip-components=1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v4.1.0
         with:
           package-dir: sdist-src
           output-dir: wheelhouse


### PR DESCRIPTION
The PyPI publish workflow references `pypa/cibuildwheel@v3`, which fails to resolve because cibuildwheel publishes no bare major (`v3`/`v4`) moving tag — the latest release is `v4.1.0`.

This pins it to `pypa/cibuildwheel@v4.1.0`, matching the TestPyPI workflow.

**Verified:** the identical fix was smoke-tested end-to-end on the TestPyPI workflow (run built manylinux/Windows/macOS wheels for CPython 3.10-3.14, uploaded to TestPyPI, and passed the cross-platform + Rocky Linux 9 test matrix).

Note: `publish-pypi.yml` reached `develop` via an accidental direct commit earlier; this corrects it through a PR.