### PR TITLE
docs: polish README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,8 @@ Build:
 
 ```shell
 cd cpp
-mkdir -p build
-cd build
-cmake ..
-make
+cmake -B build # This will create a folder named build, and configure the Makefile
+cmake --build build # This will start the build in the new folder
 ```
 
 Test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,6 @@ cd cpp/build
 
 See more details: [README.md for Python](python/README.md#contributing)
 
-Requirements:
-
-* Python 3.8, [Ruff](https://docs.astral.sh/ruff/), [mypy](https://mypy-lang.org/)
-
 Code style:
 
 * Specified in [pyproject.toml](python/pyproject.toml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,8 @@ The [`Build and Test`](.github/workflows/build-and-test.yml) workflow
 additionally performs:
 
 * C++ build and unit tests
-* Python unit tests for Python 3.8 to 3.11
-* Python package installation for Python 3.8 to 3.11
+* Python unit tests for Python 3.10 to 3.14
+* Python package installation for Python 3.10 to 3.14
 
 See more details:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ mypy .
 Test:
 
 ```shell
-python3 -m unittest discover -v
+python -m unittest discover -v
 ```
 
 ## Continuous Integration (CI) with GitHub Actions

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The memory usage is measured by `pmap`.
 ## Python Implementation
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/HenryRLee/PokerHandEvaluator/Build%20and%20Test?color=green&logo=github)](https://github.com/HenryRLee/PokerHandEvaluator/actions/workflows/build-and-test.yml)
-[![PyPI version](https://badge.fury.io/py/phevaluator.svg)](https://badge.fury.io/py/phevaluator)
+[![PyPI version](https://img.shields.io/pypi/v/phevaluator)](https://pypi.org/project/phevaluator/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/phevaluator)](https://shields.io/category/downloads)
 [![Apache_2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/HenryRLee/PokerHandEvaluator/blob/master/python/LICENSE)
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # PH Evaluator Python package (phevaluator)
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/HenryRLee/PokerHandEvaluator/Build%20and%20Test?color=green&logo=github)](https://github.com/HenryRLee/PokerHandEvaluator/actions/workflows/build-and-test.yml)
-[![PyPI version](https://badge.fury.io/py/phevaluator.svg)](https://badge.fury.io/py/phevaluator)
+[![PyPI version](https://img.shields.io/pypi/v/phevaluator)](https://pypi.org/project/phevaluator/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/phevaluator)](https://shields.io/category/downloads)
 [![Apache_2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/HenryRLee/PokerHandEvaluator/blob/master/python/LICENSE)
 

--- a/python/README.md
+++ b/python/README.md
@@ -176,8 +176,6 @@ To ensure a smooth contribution process, please follow the guidelines below.
 
 * Python 3.10 or newer
 * A C compiler (the evaluator is built as a C extension)
-* [Ruff](https://docs.astral.sh/ruff/) for linting and formatting
-* [mypy](https://mypy-lang.org/) for type checking
 
 ### Code style
 

--- a/python/README.md
+++ b/python/README.md
@@ -202,25 +202,3 @@ pip install -e .
 
 This allows the installed package to automatically reflect changes made in the `phevaluator`
 folder.
-
-### Building the Package
-
-To build the package, run the following command:
-
-```shell
-python -m build
-```
-
-This will create a `dist` folder containing the built package.
-
-Install the built package for testing:
-
-```shell
-pip install dist/*.whl
-```
-
-Check whether your distribution's long description will render correctly on PyPI:
-
-```shell
-python -m twine check dist/*
-```


### PR DESCRIPTION
## Summary

Documentation polish across the READMEs and CONTRIBUTING. No code changes.

## Changes

- **PyPI version badge → shields.io** (`README.md`, `python/README.md`): `badge.fury.io` renders are cached aggressively through GitHub's image proxy and lagged behind PyPI (still showed `0.5.3.1` after `0.6.0` shipped). `https://img.shields.io/pypi/v/phevaluator` reflects the published version reliably.
- **`python/README.md`**
  - Dropped **Ruff** and **mypy** from the contributor *Requirements* (they're enforced by the Lint & Suggest workflow).
  - Removed the **Building the Package** section (build / install-wheel / twine-check are handled by the publish workflows).
- **`CONTRIBUTING.md`**
  - Removed the outdated *Requirements* block from the Python development section (referenced Python 3.8).
  - Updated the C++ **Build** commands to the `cmake -B build` / `cmake --build build` style, matching `cpp/README`.
  - Updated supported Python versions from **3.8–3.11** to **3.10–3.14** (matches the CI matrix and `pyproject.toml`).
  - `python3` → `python` in the test command.
