### PR TITLE
docs: set 0.6.0 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [0.6.0] - Unreleased
+## [0.6.0] - 2026-07-11
 
 ### C/C++
 


### PR DESCRIPTION
Sets the `0.6.0` changelog heading from `Unreleased` to the release date **2026-07-11**, in preparation for tagging `v0.6.0`.

```diff
-## [0.6.0] - Unreleased
+## [0.6.0] - 2026-07-11
```

Format matches the existing dated entries (`YYYY-MM-DD`).