### PR TITLE
ci: publish docs only when master changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [develop]
+    branches: [master]
     paths:
       - "docs/**"
       - "Documentation/Algorithm.md"
@@ -11,7 +11,7 @@ on:
       - "cpp/README.md"
       - ".github/workflows/docs.yml"
   pull_request:
-    branches: [develop]
+    branches: [develop, master]
     paths:
       - "docs/**"
       - "Documentation/Algorithm.md"
@@ -52,8 +52,9 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    # Only publish from the default branch; PRs just build to catch errors.
-    if: github.ref == 'refs/heads/develop' && github.event_name != 'pull_request'
+    # Only publish when the master branch changes; PRs (and other branches)
+    # just build to catch errors.
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Changes the Docs workflow so GitHub Pages is **published only when the `master` branch changes**, instead of `develop`.

- `push` trigger: `develop` → **`master`** (builds and deploys).
- `pull_request` trigger: `develop` → **`develop`, `master`** (build-only validation, no deploy).
- Deploy job guard: `github.ref == 'refs/heads/master'` (was `develop`).
- `workflow_dispatch` still allowed (deploys only when run on `master`).

This ties the published documentation to the release (`master`) branch while keeping doc-build validation on PRs.

Note: publishing will only occur once `master` receives these docs changes (e.g., on the next `develop` → `master` release merge).