### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 ## [0.6.1] - Unreleased
 
-_To be documented._
+_No changes so far._
 
 ## [0.6.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.6.1] - Unreleased
+
+_To be documented._
+
 ## [0.6.0] - 2026-07-11
 
 ### C/C++

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(PokerHandEvaluator VERSION 0.6.0)
+project(PokerHandEvaluator VERSION 0.6.1)
 
 set(CMAKE_BUILD_TYPE  "Release")
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phevaluator"
-version = "0.6.0"
+version = "0.6.1"
 requires-python = ">=3.10, <4"
 authors = [
     {name = "Henry Lee", email = "lee0906@hotmail.com"}


### PR DESCRIPTION
Starts the next development cycle.

- `cpp/CMakeLists.txt`: `project(... VERSION 0.6.0)` → `0.6.1`
- `python/pyproject.toml`: `version = "0.6.0"` → `"0.6.1"`
- `CHANGELOG.md`: add an `## [0.6.1] - Unreleased` placeholder above the 0.6.0 entry

The docs pick up the version automatically from `pyproject.toml`.